### PR TITLE
Add macOS installation and launch scripts for Flowintel 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,43 @@
+# Ignore Python compiled files
 *.pyc
+
+# Ignore SQLite database files
 *.sqlite
+
+# Ignore history directory contents
 history/*
+
+# Ignore uploads directory contents
 uploads/*
+
+# Ignore specific error file
 mermaid-filter.err
+
+# Ignore matrix store files in notify_user module
 app/modules/notify_user/matrix_store/*
+
+# Ignore matrix session file in notify_user module
 app/modules/notify_user/matrix_session.txt
+
+# Ignore environment files
 env/*
+
+# Ignore log files
 *.log
+
+# Ignore virtual environment directory
+.venv/*
+
+# Ignore __pycache__ directory
+__pycache__/
+
+# Ignore IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Local development
+.env
+.env.local
+tmp/

--- a/install_macos.sh
+++ b/install_macos.sh
@@ -1,0 +1,130 @@
+#!/bin/zsh
+
+# === Styling ===
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+CYAN=$(tput setaf 6)
+BOLD=$(tput bold)
+RESET=$(tput sgr0)
+
+print_step() {
+  echo "${BOLD}${CYAN}➡️  $1${RESET}"
+}
+
+print_success() {
+  echo "${GREEN}✅ $1${RESET}"
+}
+
+print_warning() {
+  echo "${RED}⚠️  $1${RESET}"
+}
+
+# === Script starts ===
+
+print_step "Checking for Homebrew..."
+if ! command -v brew >/dev/null 2>&1; then
+  print_warning "Homebrew is not installed. Please install it from https://brew.sh and re-run this script."
+  exit 1
+fi
+
+print_step "Updating Homebrew and installing required packages... 🍺"
+brew update
+brew install python git screen wget olm librsvg
+
+print_step "Installing Pandoc via Homebrew 📝"
+brew install pandoc
+
+# NOTE 2: LaTeX — using lightweight BasicTeX
+print_step "Installing BasicTeX (lightweight LaTeX distribution) 📦"
+brew install --cask basictex
+
+# NOTE: tlmgr is not available until we add TeX binaries to the PATH
+print_step "Adding TeX binaries to PATH..."
+
+# Optional: Add to shell config permanently
+echo 'export PATH="/Library/TeX/texbin:$PATH"' >> "$HOME/.zshrc"
+
+source "$HOME/.zshrc"
+
+print_step "Installing required LaTeX packages via tlmgr... ✨"
+sudo tlmgr update --self
+sudo tlmgr install collection-latexextra collection-fontsrecommended xetex
+
+print_step "Installing Eisvogel template for PDF export 🧊"
+mkdir -p ~/.pandoc/templates
+wget -q https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest/download/Eisvogel.tar.gz
+tar -xf Eisvogel.tar.gz
+cp Eisvogel-*/eisvogel.latex ~/.pandoc/templates
+rm -rf Eisvogel.tar.gz Eisvogel-*
+
+print_step "Installing nvm and Node.js... 🧙‍♂️"
+export NVM_DIR="$HOME/.nvm"
+if [ ! -d "$NVM_DIR" ]; then
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+
+# Reload nvm
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh"
+else
+  print_warning "nvm script not found!"
+  exit 1
+fi
+
+nvm install --lts
+nvm use --lts
+
+print_step "Installing Node.js tools for export 📦"
+npm install --prefix "$HOME" mermaid-filter
+npm install --prefix "$HOME" @mermaid-js/mermaid-cli
+
+# NOTE 3: Add to zsh config (macOS default shell)
+print_step "Adding nvm and node_modules to PATH in ~/.zshrc 🛠️"
+PROFILE_FILE="$HOME/.zshrc"
+{
+  echo ""
+  echo "# nvm config and node_modules/.bin path"
+  echo "export NVM_DIR=\"$NVM_DIR\""
+  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\""
+  echo "export PATH=\"\$PATH:$HOME/node_modules/.bin\""
+} >> "$PROFILE_FILE"
+
+print_success "Environment config added to $PROFILE_FILE"
+
+print_step "Configuring mmdc proxy for Puppeteer 🕸️"
+if [ -f "$HOME/node_modules/.bin/mmdc" ]; then
+  mv "$HOME/node_modules/.bin/mmdc" "$HOME/node_modules/.bin/mmdc.orig"
+fi
+
+cat <<EOF > "$HOME/node_modules/.bin/puppeteer.json"
+{
+    "args": [
+        "--no-sandbox"
+    ]
+}
+EOF
+
+# NOTE 4: "--no-sandbox" disables browser isolation protections — ⚠️ not for production
+cat <<EOF > "$HOME/node_modules/.bin/mmdc"
+#!/bin/bash
+"\$HOME/node_modules/.bin/mmdc.orig" -p "\$HOME/node_modules/.bin/puppeteer.json" "\$@"
+EOF
+
+chmod +x "$HOME/node_modules/.bin/mmdc"
+
+print_step "Creating Python virtual environment 🐍"
+python3 -m venv env
+source env/bin/activate
+
+print_step "Installing Python requirements... 📄"
+pip install -r requirements.txt
+
+print_step "Initializing Git submodules... 🔁"
+git submodule init && git submodule update
+
+print_step "Making launch.sh executable and running it 🚀"
+chmod +x launch_macos.sh
+./launch_macos.sh -i
+
+print_success "All done! 🎉 flowintel is now ready to use."

--- a/launch_macos.sh
+++ b/launch_macos.sh
@@ -1,0 +1,118 @@
+#!/bin/zsh -i
+
+# Retrieve screen session IDs for fcm and misp_mod_flowintel
+isscripted_fcm=$(screen -ls | grep -E '[0-9]+\.fcm' | cut -d. -f1)
+isscripted_misp_mod=$(screen -ls | grep -E '[0-9]+\.misp_mod_flowintel' | cut -d. -f1)
+
+# Activate the Python virtual environment
+source env/bin/activate
+
+# Determine the directory of this script (history directory)
+history_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
+
+function killscript {
+    if [ "$isscripted_fcm" ]; then
+        screen -X -S fcm quit
+    fi
+    if [ "$isscripted_misp_mod" ]; then
+        screen -X -S misp_mod_flowintel quit
+    fi
+}
+
+function taxo_galaxy_update {
+    export FLASKENV="development"
+    python3 app.py -tg
+}
+
+function misp_module_update {
+    export FLASKENV="development"
+
+    screen -dmS "misp_mod_flowintel"
+    screen -S "misp_mod_flowintel" -X screen -t "misp_modules_server" bash -c "misp-modules -l 127.0.0.1; read x"
+
+    sleep 3
+    python3 app.py -mm
+
+    killscript
+}
+
+function launch {
+    export FLASKENV="development"
+    export HISTORY_DIR="$history_dir/history"
+    killscript
+    screen -dmS "fcm"
+    screen -S "fcm" -X screen -t "recurring_notification" bash -c "python3 startNotif.py; read x"
+    screen -dmS "misp_mod_flowintel"
+    screen -S "misp_mod_flowintel" -X screen -t "misp_modules_server" bash -c "misp-modules -l 127.0.0.1; read x"
+    python3 app.py
+}
+
+function test {
+    export FLASKENV="testing"
+    export HISTORY_DIR="$history_dir/history_test"
+    pytest
+    rm -r "$HISTORY_DIR"
+}
+
+function production {
+    export FLASKENV="development"
+    export HISTORY_DIR="$history_dir/history"
+    killscript
+    db_upgrade
+    screen -dmS "fcm"
+    screen -S "fcm" -X screen -t "recurring_notification" bash -c "python3 startNotif.py; read x"
+    screen -dmS "misp_mod_flowintel"
+    screen -S "misp_mod_flowintel" -X screen -t "misp_modules_server" bash -c "misp-modules -l 127.0.0.1; read x"
+    gunicorn -w 4 'app:create_app()' -b 127.0.0.1:7006 --access-logfile -
+}
+
+function init_db {
+    export FLASKENV="development"
+    export HISTORY_DIR="$history_dir/history"
+
+    screen -dmS "misp_mod_flowintel"
+    screen -S "misp_mod_flowintel" -X screen -t "misp_modules_server" bash -c "misp-modules -l 127.0.0.1; read x"
+
+    python3 app.py -i
+    python3 app.py -tg
+    python3 app.py -mm
+
+    killscript
+}
+
+function reload_db {
+    export HISTORY_DIR="$history_dir/history"
+    python3 app.py -r
+}
+
+if [ "$1" ]; then
+    case $1 in
+        -l|--launch )
+            launch;
+            ;;
+        -i|--init_db )
+            init_db;
+            ;;
+        -r|--reload_db )
+            reload_db;
+            ;;
+        -p|--production )
+            production;
+            ;;
+        -t|--test )
+            test;
+            ;;
+        -ks|--killscript )
+            killscript;
+            ;;
+        -tg|--taxo_galaxy )
+            taxo_galaxy_update;
+            ;;
+        -mm|--misp_modules )
+            misp_module_update;
+            ;;
+    esac
+    shift
+else
+    launch
+fi


### PR DESCRIPTION
### What's new

This PR introduces macOS support for Flowintel with the following additions:

- `install_macos.sh`: full installation script for macOS, including dependencies (Python, Pandoc, LaTeX, Node.js, mmdc proxy setup, etc.)
- `launch_macos.sh`: launches Flowintel locally using `screen` sessions for misp-modules and recurring notification
- `.gitignore` update: added exclusions for virtual environments (`env/`, `venv/`) and IDE-specific folders (`.vscode/`, `.idea/`)

### Why
This setup enables macOS users to install and run Flowintel locally, with minimal configuration and full dev tooling support.

### Notes
- All scripts are written in **Zsh**, as it is the default shell on macOS since macOS Catalina (10.15).  