### PR TITLE
PATCH: missing docker defauly user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,9 @@ RUN script -q -c "./launch.sh --init_db" /dev/null
 RUN screen -wipe || true
 
 # Final permissions check (in case)
-RUN chmod +x ./launch.sh
+RUN chmod +x ./launch.sh ./install.sh
 
+RUN ./install.sh
 
 # Default command: interactive bash + launch
 CMD ["bash", "-i", "./launch.sh", "-l"]

--- a/install.sh
+++ b/install.sh
@@ -71,4 +71,4 @@ pip install -r requirements.txt
 # init submodules
 git submodule init && git submodule update
 # make launch script executable
-./launch.sh -i
+#./launch.sh -i


### PR DESCRIPTION
use the regular install script in docker to ensure that a docker deployment matches a bare-metal one.

this is a patch i applied to the latest release version, it was not tested on the latest code in the repo.