### PR TITLE
Production deployment: doc, .env, db schema fix

### DIFF
--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -1,0 +1,142 @@
+## Production Deployment – Flowintel with Docker
+
+To deploy **Flowintel** in production mode using Docker, follow the steps below:
+
+---
+
+### 1. Configure the application
+
+Edit [`conf/config.py`](./conf/config.py) and set `ProductionConfig` as the default configuration:
+
+```python
+config = {
+    'development': DevelopmentConfig,
+    'testing': TestingConfig,
+    'production': ProductionConfig,
+    'default': ProductionConfig
+}
+```
+
+Update the database URI if needed.
+
+---
+
+### 2. Disable database initialization during image build
+
+Edit the [`Dockerfile`](./Dockerfile) and **remove or comment out** the following line:
+
+```Dockerfile
+RUN script -q -c "./launch.sh --init_db" /dev/null
+```
+
+❗ **Important:** The database must **not** be initialized during image build. Initialization must be performed **after** the database service is running.
+
+---
+
+### 3. Set the environment to production
+
+Run the following command to replace all `FLASKENV="development"` with `FLASKENV="production"` in `launch.sh`:
+
+```bash
+sed -i 's/FLASKENV="development"/FLASKENV="production"/g' launch.sh
+```
+
+---
+
+### 4. Add PostgreSQL dependency
+
+Ensure your database adapter package is included in your `requirements.txt`, for PostgreSQL:
+
+```
+psycopg2-binary
+```
+
+---
+
+### 5. Build the Docker image
+
+Build the Docker image using:
+
+```bash
+docker build -t flowintel:{tag} .
+```
+
+Replace `{tag}` with your desired version tag (e.g. `latest`, `v1.6.1`, etc.).
+
+---
+
+### 6. Set up `docker-compose.yml`
+
+Here is a template `docker-compose.yml` file with PostgreSQL:
+
+```yml
+services:
+  postgresql:
+    container_name: postgres
+    image: postgres:17
+    ports:
+      - '${POSTGRES_PORT}:5432'
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
+    networks:
+      - net
+    restart: unless-stopped
+
+  app:
+    image: flowintel:{tag}
+    container_name: flowintel
+    ports:
+      - '${APP_PORT}:7006'
+    networks:
+      - net
+    depends_on:
+      - postgresql
+    environment:
+      - DB_HOST=postgresql
+      - DB_PORT=${POSTGRES_PORT}
+      - DB_USER=${POSTGRES_USER}
+      - DB_PASSWORD=${POSTGRES_PASSWORD}
+      - DB_NAME=${POSTGRES_DB}
+    restart: unless-stopped
+
+volumes:
+  db:
+
+networks:
+  net:
+    driver: bridge
+```
+---
+### 7. Configure environment variables
+Copy the environment template and edit it:
+```bash
+cp template.env .env
+```
+
+Update the variables as needed (`POSTGRES_USER`, `POSTGRES_PASSWORD`, etc.).
+
+---
+
+### 8. Start the containers
+
+Launch all services using:
+
+```bash
+docker compose up -d
+```
+
+---
+
+### 9. Initialize the database
+
+Once the containers are running, initialize the database with:
+
+```bash
+docker exec -it flowintel bash -i ./launch.sh --init_db
+```
+
+---

--- a/app/db_class/db.py
+++ b/app/db_class/db.py
@@ -390,7 +390,7 @@ class Case_Org(db.Model):
 
 class Notification(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    message = db.Column(db.String(60), index=True)
+    message = db.Column(db.String, index=True)
     is_read = db.Column(db.Boolean, default=False)
     user_id = db.Column(db.Integer, index=True)
     case_id = db.Column(db.Integer, index=True)
@@ -909,7 +909,7 @@ class Misp_Module_Config(db.Model):
     
 class Custom_Tags(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String(25), index=True, unique=True)
+    name = db.Column(db.String, index=True, unique=True)
     color = db.Column(db.String(20), index=True)
     icon = db.Column(db.String, index=True, nullable=True)
     is_active = db.Column(db.Boolean, default=True)

--- a/conf/config.py
+++ b/conf/config.py
@@ -1,3 +1,4 @@
+import os
 class Config:
     SECRET_KEY = 'SECRET_KEY_ENV_VAR_NOT_SET'
     
@@ -28,7 +29,19 @@ class TestingConfig(Config):
                 YOU SHOULD NOT SEE THIS IN PRODUCTION.')
 
 class ProductionConfig(Config):
-    SQLALCHEMY_DATABASE_URI = "sqlite:///flowintel.sqlite"
+    # environment variables
+    db_user = os.getenv('DB_USER', 'default_user')
+    db_password = os.getenv('DB_PASSWORD', 'default_password')
+    db_host = os.getenv('DB_HOST', 'localhost')
+    db_port = os.getenv('DB_PORT', '5432')
+    db_name = os.getenv('DB_NAME', 'default_db')
+
+    # Database URI
+    SQLALCHEMY_DATABASE_URI = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+
+    @classmethod
+    def init_app(cls, app):
+        print('THIS APP IS IN PRODUCTION MODE.')
 
 config = {
     'development': DevelopmentConfig,

--- a/template.env
+++ b/template.env
@@ -1,0 +1,8 @@
+# PostgreSQL database configuration 
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_PORT=5432
+
+# App configuration
+APP_PORT=7006


### PR DESCRIPTION
Doc made for production deployment,
.env integration,
fix on notification and custom_tags schema:
issue : notification "message" field was restricting case title length to 32 characters during completion, doing so would result in a server internal error,
custom tags creation with API raised error if name > 32 characters. 