### PR TITLE
Use event uuid instead of event id for connector identifiers

### DIFF
--- a/app/case/CaseCore.py
+++ b/app/case/CaseCore.py
@@ -941,9 +941,9 @@ class CaseCore(CommonAbstract, FilteringAbstract):
         #######
         # RUN #
         #######
-        event_id, object_uuid_list = MODULES[module].handler(instance, case, user)
+        event_uuid, object_uuid_list = MODULES[module].handler(instance, case, user)
 
-        res = CommonModel.module_error_check(event_id)
+        res = CommonModel.module_error_check(event_uuid)
         if res:
             return res
 
@@ -954,20 +954,20 @@ class CaseCore(CommonAbstract, FilteringAbstract):
             cc_instance = Case_Connector_Instance(
                 case_id=case["id"],
                 instance_id=instance["id"],
-                identifier=event_id
+                identifier=event_uuid
             )
             db.session.add(cc_instance)
             db.session.commit()
-        elif not case_instance.identifier == event_id:
-            case_instance.identifier = event_id
+        elif not case_instance.identifier == event_uuid:
+            case_instance.identifier = event_uuid
             db.session.commit()
         
         if object_uuid_list:
             self.result_misp_object_module(object_uuid_list, instance["id"])
             loc_instance = Case_Misp_Object_Connector_Instance.query.filter_by(case_id=case["id"], instance_id=instance["id"]).first()
             if loc_instance:
-                if not loc_instance.identifier == event_id:
-                    loc_instance.identifier = event_id
+                if not loc_instance.identifier == event_uuid:
+                    loc_instance.identifier = event_uuid
                     db.session.commit()                
         
         CommonModel.save_history(case["uuid"], user, f"Case Module {module} used on instance: {instance['name']}")
@@ -1267,9 +1267,9 @@ class CaseCore(CommonAbstract, FilteringAbstract):
         #######
         # RUN #
         #######
-        event_id, object_uuid_list = MODULES["misp_object_event"].handler(instance, case, user)
+        event_uuid, object_uuid_list = MODULES["misp_object_event"].handler(instance, case, user)
 
-        res = CommonModel.module_error_check(event_id)
+        res = CommonModel.module_error_check(event_uuid)
         if res:
             return res
 
@@ -1277,8 +1277,8 @@ class CaseCore(CommonAbstract, FilteringAbstract):
         # RESULTS #
         ###########
 
-        if not object_instance.identifier == event_id:
-            object_instance.identifier = event_id
+        if not object_instance.identifier == event_uuid:
+            object_instance.identifier = event_uuid
             db.session.commit()
         if object_uuid_list:
             self.result_misp_object_module(object_uuid_list, object_instance.id)

--- a/app/case/TaskCore.py
+++ b/app/case/TaskCore.py
@@ -587,8 +587,8 @@ class TaskCore(CommonAbstract, FilteringAbstract):
         #######
         # RUN #
         #######
-        event_id = MODULES[module].handler(instance, case, task, user)
-        res = CommonModel.module_error_check(event_id)
+        event_uuid = MODULES[module].handler(instance, case, task, user)
+        res = CommonModel.module_error_check(event_uuid)
         if res:
             return res
         
@@ -600,13 +600,13 @@ class TaskCore(CommonAbstract, FilteringAbstract):
             tc_instance = Task_Connector_Instance(
                 task_id=task["id"],
                 instance_id=instance["id"],
-                identifier=event_id
+                identifier=event_uuid
             )
             db.session.add(tc_instance)
             db.session.commit()
 
-        elif not task_instance.identifier == event_id:
-            task_instance.identifier = event_id
+        elif not task_instance.identifier == event_uuid:
+            task_instance.identifier = event_uuid
             db.session.commit()
 
         CommonModel.save_history(case["uuid"], user, f"Task Module {module} used on instances: {instance['name']}")

--- a/app/modules/send_to/misp_event.py
+++ b/app/modules/send_to/misp_event.py
@@ -340,7 +340,7 @@ def handler(instance, case, user):
     
     if "errors" in event:
         return event, object_uuid_list
-    return event.get("id"), object_uuid_list
+    return event.get("uuid"), object_uuid_list
 
 def introspection():
     return module_config

--- a/app/modules/send_to/misp_event_task.py
+++ b/app/modules/send_to/misp_event_task.py
@@ -230,7 +230,7 @@ def handler(instance, case, task, user):
     
     if "errors" in event:
         return event
-    return event.get("id")
+    return event.get("uuid")
 
 def introspection():
     return module_config

--- a/app/modules/send_to/misp_object_event.py
+++ b/app/modules/send_to/misp_object_event.py
@@ -135,7 +135,7 @@ def handler(instance, case, user):
 
     if "errors" in event:
         return event, object_uuid_list
-    return event.get("id"), object_uuid_list
+    return event.get("uuid"), object_uuid_list
 
 def introspection():
     return module_config


### PR DESCRIPTION
Event id change on delegation in MISP, so use the uuid (which is immutable) is more secure for long term usage

Set an event id on connector's creation still works, but will be replace by the uuid after first send_to.  