### PR TITLE
Add connectors in case template

### DIFF
--- a/app/case/CaseCore.py
+++ b/app/case/CaseCore.py
@@ -932,7 +932,9 @@ class CaseCore(CommonAbstract, FilteringAbstract):
         user_instance = CommonModel.get_user_instance_both(user.id, instance.id)
 
         instance = instance.to_json()
-        if user_instance:
+        if "global_api_key" in instance and instance["global_api_key"]:
+            instance["api_key"] = instance["global_api_key"]
+        elif user_instance:
             instance["api_key"] = user_instance.api_key
         instance["identifier"] = case_instance.identifier
 

--- a/app/connectors/connectors.py
+++ b/app/connectors/connectors.py
@@ -181,6 +181,7 @@ def edit_instance(cid, iid):
             form.name.data = loc_instance.name
             form.url.data = loc_instance.url
             form.description.data = loc_instance.description
+            form.is_global_connector.data = True if loc_instance.global_api_key else False
             
         return render_template("connectors/add_instance.html", form=form, edit_mode=True)
     return render_template("404.html")

--- a/app/connectors/connectors_core.py
+++ b/app/connectors/connectors_core.py
@@ -81,7 +81,8 @@ def add_connector_instance_core(cid, form_dict, user_id):
         url=form_dict["url"],
         uuid=str(uuid.uuid4()),
         connector_id=cid,
-        type=type_select
+        type=type_select,
+        global_api_key=form_dict["api_key"] if form_dict["is_global_connector"] else None
     )
     db.session.add(connector)
     db.session.commit()

--- a/app/connectors/form.py
+++ b/app/connectors/form.py
@@ -6,7 +6,8 @@ from wtforms.fields import (
     SubmitField,
     SelectField,
     TextAreaField,
-    HiddenField
+    HiddenField,
+    BooleanField
 )
 from wtforms.validators import InputRequired, Length, Optional
 from ..db_class.db import Connector, Connector_Icon, Connector_Instance
@@ -29,7 +30,8 @@ class AddConnectorInstanceForm(FlaskForm):
     description = TextAreaField('Description', default="", validators=[Optional()])
     url = StringField('Url', validators=[InputRequired(), Length(0, 64)])
     api_key = StringField('Api key', validators=[Optional(), Length(0, 100)])
-    type_select= SelectField(u'Type', coerce=str, validators=[Optional()])
+    type_select = SelectField(u'Type', coerce=str, validators=[Optional()])
+    is_global_connector = BooleanField('Global connector', validators=[Optional()])
     
     submit = SubmitField('Add')
         
@@ -54,6 +56,7 @@ class EditConnectorInstanceForm(FlaskForm):
     url = StringField('Url', validators=[InputRequired(), Length(0, 64)])
     api_key = StringField('Api key', validators=[Optional(), Length(0, 100)])
     type_select= SelectField(u'Type', coerce=str, validators=[Optional()])
+    is_global_connector = BooleanField('Global connector', validators=[Optional()])
     
     submit = SubmitField('Modify')
         

--- a/app/db_class/db.py
+++ b/app/db_class/db.py
@@ -466,7 +466,7 @@ class Case_Template(db.Model):
                                                     .where(Cluster.id==Case_Template_Galaxy_Tags.cluster_id).all()]
         json_dict["custom_tags"] = [custom_tag.to_json() for custom_tag in Custom_Tags.query.join(Case_Template_Custom_Tags, Case_Template_Custom_Tags.custom_tag_id==Custom_Tags.id)\
                                                     .where(Case_Template_Custom_Tags.case_template_id==self.id).all()]
-
+        json_dict["connector_instances"] = [connector_instance.to_json() for connector_instance in Case_Template_Connector_Instance.query.filter(Case_Template_Connector_Instance.case_template_id==self.id).all()]
 
         return json_dict
     
@@ -779,6 +779,7 @@ class Connector_Instance(db.Model):
     uuid = db.Column(db.String(36), index=True)
     type = db.Column(db.String(36), index=True)
     connector_id = db.Column(db.Integer, db.ForeignKey('connector.id', ondelete="CASCADE"))
+    global_api_key = db.Column(db.String(100), index=True)
 
     def to_json(self):
         json_dict = {
@@ -788,7 +789,8 @@ class Connector_Instance(db.Model):
             "description": self.description,
             "uuid": self.uuid,
             "connector_id": self.connector_id,
-            "type": self.type
+            "type": self.type,
+            "global_api_key": self.global_api_key
         }
         return json_dict
 
@@ -827,6 +829,22 @@ class Case_Connector_Instance(db.Model):
     case_id = db.Column(db.Integer, index=True)
     instance_id = db.Column(db.Integer, index=True)
     identifier = db.Column(db.String)
+
+
+class Case_Template_Connector_Instance(db.Model):
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    case_template_id = db.Column(db.Integer, index=True)
+    connector_instance_id = db.Column(db.Integer, index=True)
+    identifier = db.Column(db.String)
+
+    def to_json(self):
+        return {
+            "id": self.id, 
+            "case_template_id": self.case_template_id,
+            "instance": Connector_Instance.query.filter_by(id=self.connector_instance_id).first().to_json(),
+            "identifier": self.identifier
+        }
+
 
 class Task_Connector_Instance(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)

--- a/app/static/js/templating/TemplateConnectors.js
+++ b/app/static/js/templating/TemplateConnectors.js
@@ -1,0 +1,275 @@
+import {display_toast, create_message} from '../toaster.js'
+const { ref, onMounted } = Vue
+export default {
+    delimiters: ['[[', ']]'],
+    props: {
+        template_connectors_list: Object,
+        all_connectors_list: Object,
+        is_case: Boolean,
+        object_id: Number,
+        cases_info: Object
+    },
+    emits: ['case_connectors', 'task_connectors'],
+    setup(props, {emit}) {
+        const connector_instances_selected = ref([])
+        const edit_instance = ref()
+
+        let modal_indentifier = ""
+        if(props.is_case){
+            modal_indentifier = "case-" + props.object_id
+        }else{
+            modal_indentifier = "task-" + props.object_id
+        }
+
+        async function add_connector(){
+            let connector_dict = []
+            for(let i in connector_instances_selected.value){
+                connector_dict.push({
+                    "id": connector_instances_selected.value[i].id,
+                    "name": connector_instances_selected.value[i].name,
+                    "identifier": $("#identifier_"+connector_instances_selected.value[i].id).val()
+                })
+            }
+
+            let url
+            if(props.is_case){
+                url = "/templating/"+ window.location.pathname.split("/").slice(-1) +"/add_connector"
+            }else{
+                url = "/templating/task/"+props.object_id+"/add_connector"
+            }
+
+            const res = await fetch(url, {
+                method: "POST",
+                headers: {
+                    "X-CSRFToken": $("#csrf_token").val(), "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    "connector_instances": connector_dict
+                })
+            })
+            if(await res.status==200){
+                connector_instances_selected.value = []
+                if (props.is_case){
+                    emit("case_connectors", true)
+                }else{
+                    emit("task_connectors", true)
+                }
+                $("#modal-add-connectors-"+modal_indentifier).modal("hide");
+            }
+            display_toast(res)
+        }
+
+        async function remove_connector(element_instance_id) {
+            let url
+            if(props.is_case){
+                url = "/templating/connectors/"+element_instance_id+"/remove_connector"
+            }else{
+                url = "/templating/task/"+props.object_id+"/remove_connector/"+element_instance_id
+            }
+
+            const res = await fetch(url)
+            if(await res.status==200){
+                let loc
+                for(let i in props.template_connectors_list){
+                    if(props.template_connectors_list[i].template_instance_id == element_instance_id){
+                        loc = i
+                        break
+                    }
+                }
+                props.template_connectors_list.splice(loc, 1)
+            }
+            display_toast(res)
+        }
+
+        function edit_instance_open_modal(instance){
+            edit_instance.value = instance
+            var myModal = new bootstrap.Modal(document.getElementById("modal-edit-connectors-"+modal_indentifier), {});
+            myModal.show();
+        }
+
+        async function edit_connector(){
+            let url
+            if(props.is_case){
+                url = "/templating/connectors/"+edit_instance.value.template_instance_id+"/edit_connector"
+            }else{
+                url = "/templating/task/"+props.object_id+"/edit_connector/"+edit_instance.value.template_instance_id
+            }
+
+            let loc_indentifier = $("#input-edit-connector").val()
+            const res = await fetch(url, {
+                method: "POST",
+                headers: {
+                    "X-CSRFToken": $("#csrf_token").val(), "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    "identifier": loc_indentifier
+                })
+            });
+            if(await res.status==200){
+                for (let i in props.template_connectors_list){
+                    if (props.template_connectors_list[i].template_instance_id == edit_instance.value.template_instance_id){
+                        props.template_connectors_list[i].identifier = loc_indentifier
+                    }
+                }
+                edit_instance.value = {}
+                $("#modal-edit-connectors-"+modal_indentifier).modal("hide");
+            }
+            display_toast(res)
+        }
+
+
+        onMounted(() => {
+            $('.select2-connect').select2({
+                theme: 'bootstrap-5',
+                dropdownParent: $("#modal-add-connectors-"+modal_indentifier)
+            })
+
+            $('#connectors_select_'+modal_indentifier).on('change.select2', function (e) {
+                connector_instances_selected.value = []
+                let id_connector_instances_selected = $(this).select2('data').map(item => item.id)
+
+                for(let i in id_connector_instances_selected){                    
+                    for(let connectors in props.all_connectors_list){
+                        for(let connector in props.all_connectors_list[connectors]){
+                            if(id_connector_instances_selected[i] == props.all_connectors_list[connectors][connector].id){
+                                connector_instances_selected.value.push({
+                                    "id": props.all_connectors_list[connectors][connector].id,
+                                    "name": props.all_connectors_list[connectors][connector].name,
+                                    "identifier": props.all_connectors_list[connectors][connector].identifier
+                                })
+                            }
+                        }
+                    }
+                }    
+            })
+        })
+
+        return {
+            connector_instances_selected,
+            edit_instance,
+            modal_indentifier,
+            
+            add_connector,
+            remove_connector,
+            edit_instance_open_modal,
+            edit_connector,
+        }
+    },
+    css: `
+        .tab-content {
+            border-left: 1px solid #ddd;
+            border-right: 1px solid #ddd;
+            border-bottom: 1px solid #ddd;
+            padding: 10px;
+        }
+    `,
+    template: `
+        <div class="card card-body">
+            <div>
+                <button class="btn btn-outline-primary" data-bs-toggle="modal" :data-bs-target="'#modal-add-connectors-'+modal_indentifier">
+                    <i class="fa-solid fa-plus"></i>
+                </button>
+            </div>
+            
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Instance name</th>
+                        <th>Instance url</th>
+                        <th>Type</th>
+                        <th>Identifier on the instance</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="instance in template_connectors_list">
+                        <td>
+                            <div :title="instance.details.description">
+                                <img :src="'/static/icons/'+instance.details.icon" style="max-width: 30px;">
+                                [[instance.details.name]]
+                            </div>
+                        </td>
+                        <td>
+                            <a style="margin-left: 5px" :href="instance.details.url">[[instance.details.url]]</a>
+                        </td>
+
+                        <td v-if="instance.details.type">
+                            <span style="margin-left: 3px;" title="type of the module">[[instance.details.type]]</span>
+                        </td>
+                        <td v-else><i>None</i></td>
+
+                        <td v-if="instance.identifier">
+                            <span style="margin-left: 3px;" title="identifier used by module">[[instance.identifier]]</span>
+                        </td>
+                        <td v-else><i>None</i></td>
+
+                        <td>
+                            <button class="btn btn-outline-primary" @click="edit_instance_open_modal(instance)"> <i class="fa-solid fa-pen-to-square"></i> </button>
+                            <button class="btn btn-outline-danger" @click="remove_connector(instance.template_instance_id)"> <i class="fa-solid fa-trash"></i> </button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Add Connectors -->
+        <div class="modal fade" :id="'modal-add-connectors-'+modal_indentifier" tabindex="-1" aria-labelledby="AddConnectorsLabel" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="AddConnectorsLabel">Add Connectors</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="w-50">
+                            <select data-placeholder="Connectors" class="select2-connect form-control" multiple name="connectors_select" :id="'connectors_select_'+modal_indentifier" >
+                                <template v-if="all_connectors_list">
+                                    <template v-for="(instances, connector) in all_connectors_list">
+                                        <optgroup :label="[[connector]]">
+                                            <option :value="[[instance.id]]" v-for="instance in instances">[[instance.name]]</option>
+                                        </optgroup>
+                                    </template>
+                                </template>
+                            </select>
+                        </div>
+                        <div class="row" v-if="connector_instances_selected">
+                            <div class="mb-3 w-25" v-for="c_i_s in connector_instances_selected" >
+                                <label :for="'identifier_' + c_i_s.id">[[c_i_s.name]] Complement</label>
+                                <input :id="'identifier_' + c_i_s.id" class="form-control" :name="'identifier_' + c_i_s.id" type="text">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-primary" @click="add_connector()">
+                            Save
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+        <!-- Edit Connectors -->
+        <div class="modal fade" :id="'modal-edit-connectors-'+modal_indentifier" tabindex="-1" aria-labelledby="EditConnectorsLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="EditConnectorsLabel">Edit Connectors</h1>
+                        <button type="button" class="btn-close" aria-label="Cancel"></button>
+                    </div>
+                    <div class="modal-body">
+                        <b>Identifier</b>
+                        <input type="text" v-if="edit_instance" :value="edit_instance.identifier" id="input-edit-connector">
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary" @click="edit_connector()">
+                            Save
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `
+}

--- a/app/templates/connectors/add_instance.html
+++ b/app/templates/connectors/add_instance.html
@@ -59,6 +59,13 @@
                     {%endif%}
                 </div>
             </div>
+            <div>
+                <label for="is_global_connector" class="col-form-label">Global connector:</label>
+                {{form.is_global_connector(class_="mx-2")}}
+                {% if form.is_global_connector.errors %}
+                    <div style="color: red;">{{form.is_global_connector.errors[0] | safe}}</div>
+                {%endif%}
+            </div>
             <div class="modal-footer">
                 {{form.submit(class='btn btn-primary')}}
             </div>

--- a/app/templates/templating/case_template_view.html
+++ b/app/templates/templating/case_template_view.html
@@ -111,6 +111,12 @@
                 <button class="nav-link" id="tab-note" @click="active_tab('note')">Notes</button>
             </li>
             <li class="nav-item">
+                <button class="nav-link" id="tab-connectors" @click="active_tab('connectors')">
+                    Connectors
+                    <span class="badge text-bg-secondary d-none" id="id-nb-connectors">[[case_template_connectors_list.length]]</span>
+                </button>
+            </li>
+            <li class="nav-item">
                 <button class="nav-link" id="tab-info" @click="active_tab('info')">Info</button>
             </li>
         </ul>
@@ -146,6 +152,18 @@
                         <div class="markdown-render" v-html="md.render(note_editor_render)"></div>
                     </div>
                 </template>
+            </template>
+
+            <template v-else-if="selected_tab == 'connectors'">
+                <templateconnectors v-if="case_template"
+                    :template_connectors_list="case_template_connectors_list"
+                    :all_connectors_list="all_connectors_list"
+                    :is_case="true"
+                    :object_id="case_template.id"
+                    :cases_info="case_template"
+                    @case_connectors="(msg) => fetch_case_template_connectors()"
+                    @task_connectors="">
+                </templateconnectors>
             </template>
 
             <template v-else-if="selected_tab == 'info'">
@@ -198,12 +216,15 @@
         import task_template from '/static/js/templating/task_template.js'
         import tags_edition from '/static/js/case/tags_edition.js'
         import {display_toast, message_list} from '/static/js/toaster.js'
-        
+        import templateconnectors from '/static/js/templating/TemplateConnectors.js'
+
+
         createApp({
             delimiters: ['[[', ']]'],
             components: {
                 task_template,
-                tags_edition
+                tags_edition,
+                templateconnectors
             },
             setup() {
                 const case_template = ref()
@@ -217,6 +238,9 @@
                 const md = window.markdownit()			// Library to Parse and display markdown
 		        md.use(mermaidMarkdown.default)			// Use mermaid library
 
+                const case_template_connectors_list = ref([])
+                const all_connectors_list = ref([])
+
                 async function fetch_case_template() {
                     const res = await fetch(
                         '/templating/get_case_template/{{case_id}}'
@@ -224,7 +248,6 @@
                     let loc = await res.json()
                     case_template.value = loc["template"]
                 }
-                fetch_case_template()
 
                 async function fetchTasks() {
                     tasks_list.value = null
@@ -238,6 +261,26 @@
                 async function delete_case(case_template_id){
                     const res = await fetch("/templating/delete_case/"+case_template_id)
                     return window.location.href = "/templating/cases"
+                }
+
+                async function fetch_case_template_connectors(){
+                    const res = await fetch("/templating/"+ window.location.pathname.split("/").slice(-1) +"/get_case_template_connector_instances")
+                    if(await res.status==404 ){
+                        display_toast(res)
+                    }else{
+                        let loc = await res.json()
+                        case_template_connectors_list.value = loc["connector_instances"]
+                    }
+                }
+                
+                async function fetch_connectors(){
+                    const res = await fetch("/case/get_connectors")
+                    if(await res.status==404 ){
+                        display_toast(res)
+                    }else{
+                        let loc = await res.json()
+                        all_connectors_list.value = loc["connectors"]
+                    }
                 }
 
                 async function fork_case(case_id){
@@ -293,6 +336,7 @@
                         selected_tab.value = 'note'
                         if ( !document.getElementById("tab-note").classList.contains("active") ){
                             document.getElementById("tab-note").classList.add("active")
+                            document.getElementById("tab-connectors").classList.remove("active")
                             document.getElementById("tab-main").classList.remove("active")
                             document.getElementById("tab-info").classList.remove("active")
                         }
@@ -311,12 +355,22 @@
                         }else{
                             prepare_editor()
                         }
+                    }else if(tab_name == 'connectors'){
+                        selected_tab.value = 'connectors'
+                        if ( !document.getElementById("tab-connectors").classList.contains("active") ){
+                            document.getElementById("tab-connectors").classList.add("active")
+                            document.getElementById("tab-main").classList.remove("active")
+                            document.getElementById("tab-note").classList.remove("active")
+                            document.getElementById("tab-info").classList.remove("active")
+                        }
+                        await nextTick()
                     }else if(tab_name == 'info'){
                         selected_tab.value = 'info'
                         if ( !document.getElementById("tab-info").classList.contains("active") ){
                             document.getElementById("tab-info").classList.add("active")
                             document.getElementById("tab-main").classList.remove("active")
                             document.getElementById("tab-note").classList.remove("active")
+                            document.getElementById("tab-connectors").classList.remove("active")
                         }
                     }
                 }
@@ -379,7 +433,11 @@
                 }
 
                 onMounted( async () => {
+                    await fetch_case_template()
+                    fetch_case_template_connectors()
+                    fetch_connectors()
                     await fetchTasks()
+
                     const options = {
                         animation: 150,
                         handle: '.list-group-item', // Only drag by header
@@ -436,6 +494,8 @@
                     };
 
                     new Sortable(document.getElementById('list-container'), options);
+
+                    $("#id-nb-connectors").removeClass("d-none")
                 })
                 
 
@@ -443,6 +503,8 @@
                     message_list,
                     case_template,
                     tasks_list,
+                    case_template_connectors_list,
+                    all_connectors_list,
                     selected_tab,
                     note_editor_render,
                     edit_mode,
@@ -454,6 +516,7 @@
 
                     edit_note,
                     save_note_case,
+                    fetch_case_template_connectors,
 
 
                     getTextColor,

--- a/app/templating/common_template_core.py
+++ b/app/templating/common_template_core.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Optional
 from ..db_class.db import *
 from sqlalchemy import func
+from ..case.common_core import get_instance_by_name
 
 def get_all_case_templates():
     return Case_Template.query.all()
@@ -177,3 +178,41 @@ def get_taxonomies_from_tags(tags):
             if not tag["name"].split(":")[0] in taxonomies:
                 taxonomies.append(tag["name"].split(":")[0])
     return taxonomies
+
+
+##############
+# Connectors #
+##############
+def get_case_template_connector_instances(ctid):
+    """Return a list of all connectors present in a case template"""
+    return Case_Template_Connector_Instance.query.filter_by(case_template_id=ctid).all()
+
+def add_connector_instances_to_case_template(ctid, connector_instances) -> bool:
+    """Add connector instance to case template"""
+    for connector_instance in connector_instances:
+        c = Case_Template_Connector_Instance(
+            case_template_id=ctid,
+            connector_instance_id=connector_instance["id"],
+            identifier=connector_instance['identifier']
+        )
+        db.session.add(c)
+    db.session.commit()
+    return True
+
+def edit_connector_instances_of_case_template(ctid, identifier) -> bool:
+    """Edit identifier of connector instance"""
+    c = Case_Template_Connector_Instance.query.get(ctid)
+    if c:
+        c.identifier = identifier
+        db.session.commit()
+        return True
+    return False
+
+def remove_connector_instance_from_case_template(ctid):
+    """Remove connector instance from a case template"""
+    c = Case_Template_Connector_Instance.query.get(ctid)
+    if c:
+        db.session.delete(c)
+        db.session.commit()
+        return True
+    return False

--- a/app/utils/formHelper.py
+++ b/app/utils/formHelper.py
@@ -4,13 +4,23 @@ def prepare_tags(request):
     tag_list = request.form.getlist("tags_select")
     cluster_list = request.form.getlist("clusters_select")
     custom_tags_list = request.form.getlist("custom_select")
+    instance_id_list = request.form.getlist("connector_instances")
     if isinstance(CommonModel.check_tag(tag_list), bool):
         if isinstance(CommonModel.check_cluster(cluster_list), bool):
+            connector_instances = []
+            for instance_id in instance_id_list:
+                instance_identifier = request.form.get(f"identifier_{instance_id}")
+
+                connector_instances.append({
+                    "id": instance_id,
+                    "identifier": instance_identifier
+                })
 
             return {
                 "tags": tag_list,
                 "clusters": cluster_list,
-                "custom_tags": custom_tags_list
+                "custom_tags": custom_tags_list,
+                "connector_instances": connector_instances
             }
         return "cluster error"
     return "tag error"


### PR DESCRIPTION
Add connectors in case template for multiple cases that send their data to the same instance.

# New
- Add connectors in case template
- Connector can be global (set in instance page). ie : Everyone can use it on the case
# Fix
case_template_view.py
- Sortable in onMounted() raised error sometimes when no task exist
# No change
- "create template from case", case connectors not kept in template (can be add if you think it's usefull)




One other approch for global connector is to set automatically connectors from template usable by everyone.
But I'm not shure it's a good idea, we can discuss about all these changes