### PR TITLE
Add Keycloak SSO login flow

### DIFF
--- a/app/account/account.py
+++ b/app/account/account.py
@@ -10,6 +10,7 @@ from flask_login import (
 )
 from . import account_core as AccountModel
 from . import entra_core as EntraModel
+from . import keycloak_core as KeycloakModel
 from ..utils.utils import form_to_dict
 from ..utils.logger import flowintel_log
 from ..notification import notification_core as NotifModel
@@ -17,6 +18,7 @@ import logging
 import time
 import secrets
 from urllib.parse import urlparse
+from itsdangerous import URLSafeTimedSerializer, BadData
 
 from wtforms.validators import Email, ValidationError
 
@@ -221,7 +223,7 @@ def request_password_reset():
             # SSO-managed accounts cannot reset their password here
             if user.auth_provider != 'local':
                 flowintel_log("audit", 400, "Password reset blocked for SSO user", Email=email, IP=get_client_ip())
-                flash('This account uses Microsoft Entra ID for authentication. Password management is handled by your organisation.', 'warning')
+                flash('This account uses single sign-on (SSO) for authentication. Password management is handled by your organisation.', 'warning')
                 session.pop('password_reset_token', None)
                 session.pop('password_reset_token_time', None)
                 session.pop('failed_login_email', None)
@@ -305,6 +307,69 @@ def entra_callback():
     login_user(user)
     flowintel_log("audit", 200, "Entra ID login successful", Email=user.email)
     flash('Logged in via Microsoft Entra ID.', 'success')
+    next_url = request.args.get('next') or '/'
+    if urlparse(next_url).netloc or urlparse(next_url).scheme:
+        next_url = '/'
+    return redirect(next_url)
+
+
+@account_blueprint.route('/keycloak/login')
+def keycloak_login():
+    """Redirect user to Keycloak for authentication."""
+    if not current_app.config.get('KEYCLOAK_ENABLED'):
+        abort(404)
+
+    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    state = s.dumps('keycloak-login')
+    redirect_uri = current_app.config.get('KEYCLOAK_REDIRECT_URL') or url_for('account.keycloak_callback', _external=True)
+    auth_url = KeycloakModel.get_auth_url(redirect_uri, state=state)
+    return redirect(auth_url)
+
+
+@account_blueprint.route('/keycloak/callback')
+def keycloak_callback():
+    """Handle the OAuth2 redirect from Keycloak."""
+    if not current_app.config.get('KEYCLOAK_ENABLED'):
+        abort(404)
+
+    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    try:
+        s.loads(request.args.get('state', ''), max_age=600)
+    except BadData:
+        flash('Authentication failed: invalid or expired state.', 'error')
+        flowintel_log("audit", 403, "Keycloak login failed - state mismatch", IP=get_client_ip())
+        return redirect(url_for('account.login'))
+
+    if 'error' in request.args:
+        error_desc = str(request.args.get('error_description', request.args.get('error', 'unknown error')))[:200]
+        flash(f'Keycloak authentication error: {error_desc}', 'error')
+        flowintel_log("audit", 401, "Keycloak login error", Error=request.args.get('error'), IP=get_client_ip())
+        return redirect(url_for('account.login'))
+
+    code = request.args.get('code')
+    if not code:
+        flash('Authentication failed: no authorization code received.', 'error')
+        return redirect(url_for('account.login'))
+
+    redirect_uri = current_app.config.get('KEYCLOAK_REDIRECT_URL') or url_for('account.keycloak_callback', _external=True)
+    result = KeycloakModel.exchange_code(code, redirect_uri)
+
+    if 'error' in result:
+        error_desc = str(result.get('error_description', result.get('error', 'unknown error')))[:200]
+        flash(f'Keycloak authentication error: {error_desc}', 'error')
+        flowintel_log("audit", 401, "Keycloak token exchange failed", Error=result.get('error'), IP=get_client_ip())
+        return redirect(url_for('account.login'))
+
+    user, error = KeycloakModel.get_or_create_sso_user(result)
+
+    if not user:
+        flash(f'Access denied: {error}', 'error')
+        flowintel_log("audit", 403, "Keycloak login denied", Reason=error, IP=get_client_ip())
+        return redirect(url_for('account.login'))
+
+    login_user(user)
+    flowintel_log("audit", 200, "Keycloak login successful", Email=user.email)
+    flash('Logged in via Keycloak.', 'success')
     next_url = request.args.get('next') or '/'
     if urlparse(next_url).netloc or urlparse(next_url).scheme:
         next_url = '/'

--- a/app/account/account_core.py
+++ b/app/account/account_core.py
@@ -32,7 +32,7 @@ def edit_user_core(form_dict, id, is_sso=False):
     user.first_name=form_dict["first_name"]
     user.last_name=form_dict["last_name"]
     user.nickname=form_dict["nickname"]
-    # SSO accounts have their identity managed by Entra ID; disallow email changes.
+    # SSO accounts have their identity managed externally; disallow email changes.
     if not is_sso:
         user.email=form_dict["email"]
     user.matrix_id=matrix_id

--- a/app/account/entra_core.py
+++ b/app/account/entra_core.py
@@ -168,11 +168,19 @@ def get_or_create_sso_user(id_token_claims, access_token):
             db.session.commit()
         return user, None
 
-    # Provision a new user account on first login.
-    name = id_token_claims.get("name", "")
-    parts = name.split(" ", 1)
-    first_name = parts[0] if parts else ""
-    last_name = parts[1] if len(parts) > 1 else ""
+    # Build user name from token claims, with sensible fallbacks.
+    first_name = (id_token_claims.get("given_name") or "").strip()
+    last_name = (id_token_claims.get("family_name") or "").strip()
+    if not first_name and not last_name:
+        full_name = (id_token_claims.get("name") or "").strip()
+        if full_name:
+            parts = full_name.split(" ", 1)
+            first_name = parts[0]
+            last_name = parts[1] if len(parts) > 1 else ""
+    if not first_name:
+        first_name = email.split("@")[0]
+    if not last_name:
+        last_name = ""
     nick = f"{email.split('@')[0]} - via EntraID"
 
     user = User(
@@ -196,14 +204,21 @@ def get_or_create_sso_user(id_token_claims, access_token):
     logger.info("Provisioned new Entra ID user: %s (role: %s)", email, target_role.name)
 
     if notify_admin:
-        NotifModel.create_notification_for_admins(
-            message=(
-                f"Entra ID user '{email}' is a member of '{matched_group}' and has been "
-                f"provisioned with the '{target_role.name}' role. "
-                "Please promote them to Admin if appropriate."
-            ),
-            html_icon="fa-solid fa-user-shield",
-            user_id_for_redirect=user.id,
+        msg = (
+            f"Entra ID user '{email}' is a member of '{matched_group}' and has been "
+            f"provisioned with the '{target_role.name}' role. "
+            "Please promote them to Admin if appropriate."
         )
+    else:
+        msg = (
+            f"A new Entra ID user '{email}' has been provisioned with the "
+            f"'{target_role.name}' role (group '{matched_group}'). "
+            "Please review their organisation assignment."
+        )
+    NotifModel.create_notification_for_admins(
+        message=msg,
+        html_icon="fa-solid fa-user-shield",
+        user_id_for_redirect=user.id,
+    )
 
     return user, None

--- a/app/account/keycloak_core.py
+++ b/app/account/keycloak_core.py
@@ -1,0 +1,195 @@
+import base64
+import datetime
+import json
+import logging
+from urllib.parse import urlencode
+
+import requests
+from flask import current_app
+
+from .. import db
+from ..db_class.db import Role, User
+from ..notification import notification_core as NotifModel
+from ..utils.utils import generate_api_key
+
+logger = logging.getLogger(__name__)
+
+
+def _base_url():
+    """Return the Keycloak base URL with no trailing slash."""
+    return current_app.config.get("KEYCLOAK_BASE_URL", "").rstrip("/")
+
+
+def _realm():
+    return current_app.config.get("KEYCLOAK_REALM", "flowintel")
+
+
+def _oidc_base():
+    return f"{_base_url()}/realms/{_realm()}/protocol/openid-connect"
+
+
+def get_auth_url(redirect_uri, state=None):
+    """Build the Keycloak authorization URL for the Authorization Code flow."""
+    params = {
+        "client_id": current_app.config.get("KEYCLOAK_CLIENT_ID", ""),
+        "response_type": "code",
+        "scope": "openid",
+        "redirect_uri": redirect_uri,
+    }
+    if state:
+        params["state"] = state
+
+    return f"{_oidc_base()}/auth?{urlencode(params)}"
+
+
+def exchange_code(code, redirect_uri):
+    """Exchange an authorization code for tokens. Returns the JSON token response."""
+    resp = requests.post(
+        f"{_oidc_base()}/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": current_app.config.get("KEYCLOAK_CLIENT_ID", ""),
+            "client_secret": current_app.config.get("KEYCLOAK_CLIENT_SECRET", ""),
+            "code": code,
+            "redirect_uri": redirect_uri,
+        },
+        timeout=10,
+    )
+    if resp.status_code != 200:
+        logger.warning("Keycloak token exchange failed (%s): %s", resp.status_code, resp.text[:500])
+        return {"error": "token_exchange_failed", "error_description": resp.text[:200]}
+    return resp.json()
+
+
+def _decode_jwt_payload(token):
+    """Decode the payload of a JWT without verifying the signature (back-channel token)."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1] + "=" * (4 - len(parts[1]) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+def get_or_create_sso_user(token_response):
+    """Resolve a Keycloak token response to a Flowintel User, creating one if needed.
+
+    Returns (user, None) on success or (None, error_message) on failure.
+    """
+    id_token = token_response.get("id_token")
+    if not id_token:
+        return None, "No ID token in the Keycloak response."
+
+    claims = _decode_jwt_payload(id_token)
+    if not claims:
+        return None, "Could not decode the Keycloak ID token."
+
+    email = (claims.get("email") or claims.get("preferred_username") or "").lower().strip()
+    if not email:
+        return None, "No email address found in the Keycloak token."
+
+    groups = claims.get("groups", [])
+
+    cfg = current_app.config
+    priority_list = [
+        (cfg.get("KEYCLOAK_GROUP_ADMIN",      "FlowintelAdmin"),      "Editor",                                    True),
+        (cfg.get("KEYCLOAK_GROUP_EDITOR",      "FlowintelEditor"),     "Editor",                                    False),
+        (cfg.get("KEYCLOAK_GROUP_CASE_ADMIN",  "FlowintelCaseAdmin"),  cfg.get("KEYCLOAK_ROLE_CASE_ADMIN",  "CaseAdmin"),  False),
+        (cfg.get("KEYCLOAK_GROUP_QUEUE_ADMIN", "FlowintelQueueAdmin"), cfg.get("KEYCLOAK_ROLE_QUEUE_ADMIN", "QueueAdmin"), False),
+        (cfg.get("KEYCLOAK_GROUP_QUEUER",      "FlowintelQueuer"),     cfg.get("KEYCLOAK_ROLE_QUEUER",      "Queuer"),     False),
+        (cfg.get("KEYCLOAK_GROUP_READONLY",    "FlowintelReadOnly"),   "Read Only",                                 False),
+    ]
+
+    configured_groups = [entry[0] for entry in priority_list]
+    logger.info(
+        "Keycloak login for '%s' — groups received: %s | checking: %s",
+        email, groups, configured_groups,
+    )
+
+    matched_group = None
+    matched_role_name = None
+    notify_admin = False
+    for group_name, role_name, should_notify in priority_list:
+        if group_name in groups:
+            matched_group = group_name
+            matched_role_name = role_name
+            notify_admin = should_notify
+            break
+
+    if not matched_group:
+        return None, (
+            "Your account is not a member of any Flowintel group "
+            f"({', '.join(configured_groups)})."
+        )
+
+    logger.info("Keycloak login for '%s' — matched group '%s' → role '%s'", email, matched_group, matched_role_name)
+
+    target_role = Role.query.filter_by(name=matched_role_name).first()
+    if not target_role:
+        return None, (
+            f"Could not find Flowintel role '{matched_role_name}' in the database. "
+            "Please ask an administrator to create it."
+        )
+
+    user = User.query.filter_by(email=email).first()
+
+    if user:
+        if user.auth_provider == "keycloak" and user.role_id != target_role.id:
+            user.role_id = target_role.id
+            db.session.commit()
+        return user, None
+
+    # Build user name from token claims, with sensible fallbacks.
+    first_name = (claims.get("given_name") or "").strip()
+    last_name = (claims.get("family_name") or "").strip()
+    if not first_name and not last_name:
+        full_name = (claims.get("name") or "").strip()
+        if full_name:
+            parts = full_name.split(" ", 1)
+            first_name = parts[0]
+            last_name = parts[1] if len(parts) > 1 else ""
+    if not first_name:
+        first_name = email.split("@")[0]
+    if not last_name:
+        last_name = ""
+
+    nick = f"{email.split('@')[0]} - via Keycloak"
+
+    user = User(
+        first_name=first_name,
+        last_name=last_name,
+        nickname=nick,
+        email=email,
+        role_id=target_role.id,
+        api_key=generate_api_key(),
+        auth_provider="keycloak",
+        creation_date=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    from ..admin.admin_core import create_default_org
+    org = create_default_org(user)
+    user.org_id = org.id
+    db.session.commit()
+
+    logger.info("Provisioned new Keycloak user: %s (role: %s)", email, target_role.name)
+
+    if notify_admin:
+        msg = (
+            f"Keycloak user '{email}' is a member of '{matched_group}' and has been "
+            f"provisioned with the '{target_role.name}' role. "
+            "Please promote them to Admin if appropriate."
+        )
+    else:
+        msg = (
+            f"A new Keycloak user '{email}' has been provisioned with the "
+            f"'{target_role.name}' role (group '{matched_group}'). "
+            "Please review their organisation assignment."
+        )
+    NotifModel.create_notification_for_admins(
+        message=msg,
+        html_icon="fa-solid fa-user-shield",
+        user_id_for_redirect=user.id,
+    )
+
+    return user, None

--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -105,11 +105,11 @@ def edit_user(uid):
         return redirect(url_for('admin.users'))
     
     from_notification = request.args.get('from_notif', 'false') == 'true'
-    from_notif_entra  = request.args.get('from_notif_for_entra_id', 'false') == 'true'
+    from_notif_sso    = request.args.get('from_notif_for_entra_id', 'false') == 'true'
     # Auto-detect: if this is a generic notification link but the user is SSO-managed,
-    # treat it as an Entra ID promotion notification, not a password-reset notification.
-    if from_notification and user_modif.auth_provider == 'entra':
-        from_notif_entra  = True
+    # treat it as an SSO promotion notification, not a password-reset notification.
+    if from_notification and user_modif.auth_provider in ('entra', 'keycloak'):
+        from_notif_sso    = True
         from_notification = False
     
     form = AdminEditUserFrom()
@@ -136,12 +136,12 @@ def edit_user(uid):
                 return redirect(url_for('admin.users'))
             if form.org.data != str(current_user.org_id):
                 flash("You cannot change the organization of users.", "error")
-                return render_template("admin/add_user.html", form=form, edit_mode=True, from_notification=from_notification, from_notif_entra=from_notif_entra, is_sso=(user_modif.auth_provider != 'local'))
+                return render_template("admin/add_user.html", form=form, edit_mode=True, from_notification=from_notification, from_notif_sso=from_notif_sso, is_sso=(user_modif.auth_provider != 'local'))
             
             selected_role = Role.query.get(form.role.data)
             if selected_role and selected_role.admin:
                 flash("You cannot assign Admin role to users.", "error")
-                return render_template("admin/add_user.html", form=form, edit_mode=True, from_notification=from_notification, from_notif_entra=from_notif_entra, is_sso=(user_modif.auth_provider != 'local'))
+                return render_template("admin/add_user.html", form=form, edit_mode=True, from_notification=from_notification, from_notif_sso=from_notif_sso, is_sso=(user_modif.auth_provider != 'local'))
         
         form_dict = form_to_dict(form)
         # Strip password fields for SSO accounts; never allow a password change via this form.
@@ -167,7 +167,7 @@ def edit_user(uid):
         form.role.data = str(user_modif.role_id)
         form.org.data = str(user_modif.org_id)
 
-    return render_template("admin/add_user.html", form=form, edit_mode=True, from_notification=from_notification, from_notif_entra=from_notif_entra, is_sso=(user_modif.auth_provider != 'local'))
+    return render_template("admin/add_user.html", form=form, edit_mode=True, from_notification=from_notification, from_notif_sso=from_notif_sso, is_sso=(user_modif.auth_provider != 'local'))
 
 
 @admin_blueprint.route("/delete_user/<uid>", methods=['POST'])

--- a/app/templates/account/edit_user.html
+++ b/app/templates/account/edit_user.html
@@ -66,7 +66,7 @@
                     {% if is_sso %}
                     <div class="alert alert-info py-2 mb-0">
                         <i class="fa-solid fa-shield-halved me-1"></i>
-                        This account is managed via <strong>Microsoft Entra ID</strong>. Password management is handled externally.
+                        This account is managed via <strong>single sign-on (SSO)</strong>. Password management is handled externally.
                     </div>
                     {% else %}
                     <div class="form-check">

--- a/app/templates/account/login.html
+++ b/app/templates/account/login.html
@@ -135,6 +135,15 @@
             </div>
             {% endif %}
 
+            {% if config.KEYCLOAK_ENABLED %}
+            <div class="mt-3">
+                <a href="{{ url_for('account.keycloak_login') }}" class="btn btn-outline-light w-100">
+                    <i class="fa-solid fa-shield-halved" style="margin-right:6px"></i>
+                    Sign in with Keycloak
+                </a>
+            </div>
+            {% endif %}
+
             {% if show_reset_link %}
             <div class="mt-3" style="text-align: center;">
                 <a href="{{ url_for('account.request_password_reset') }}" style="color: #ccddff;">Request password reset from administrator</a>

--- a/app/templates/admin/add_user.html
+++ b/app/templates/admin/add_user.html
@@ -22,10 +22,10 @@
         </div>
     {% endif %}
 
-    {% if edit_mode and from_notif_entra %}
+    {% if edit_mode and from_notif_sso %}
         <div class="alert alert-primary mt-3 mb-0" role="alert">
             <i class="fa-solid fa-user-shield me-2"></i>
-            <strong>Entra ID promotion request:</strong> This user signed in via Microsoft Entra ID and is a member of the admin group. Review their role and promote if appropriate.
+            <strong>New SSO user:</strong> This user was provisioned via single sign-on. Review their role and organisation assignment.
         </div>
     {% endif %}
 
@@ -97,7 +97,7 @@
                 {% if is_sso %}
                 <div class="alert alert-info py-2 mb-0">
                     <i class="fa-solid fa-shield-halved me-1"></i>
-                    This account is managed via <strong>Microsoft Entra ID</strong>. Password management is handled externally and cannot be changed here.
+                    This account is managed via <strong>single sign-on (SSO)</strong>. Password management is handled externally and cannot be changed here.
                 </div>
                 {% else %}
                 <div class="form-check">

--- a/app/templates/tools/system_settings.html
+++ b/app/templates/tools/system_settings.html
@@ -475,6 +475,81 @@
                 </div>
             </div>
 
+            <!-- ── Keycloak SSO ── -->
+            <div class="card mb-4" style="box-shadow: 0.1rem 0.3rem 0.5rem rgba(0, 0, 0, 0.1);">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary"><i class="fa-solid fa-shield-halved me-2"></i>Keycloak SSO</h6>
+                </div>
+                <div class="card-body">
+                    <table class="table table-sm table-borderless mb-0">
+                        <tbody>
+                            <tr>
+                                <td class="fw-bold" style="width: 40%;"><small class="text-danger fw-bold">CLI</small> Enabled <small class="fw-normal text-muted">(KEYCLOAK_ENABLED)</small></td>
+                                <td>
+                                    <span class="badge {% if system_info.keycloak_enabled %}bg-success{% else %}bg-secondary{% endif %}">
+                                        {{ system_info.keycloak_enabled }}
+                                    </span>
+                                </td>
+                            </tr>
+                            {% if system_info.keycloak_enabled %}
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Base URL <small class="fw-normal text-muted">(KEYCLOAK_BASE_URL)</small></td>
+                                <td><code>{{ system_info.keycloak_base_url }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Realm <small class="fw-normal text-muted">(KEYCLOAK_REALM)</small></td>
+                                <td><code>{{ system_info.keycloak_realm }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Client ID <small class="fw-normal text-muted">(KEYCLOAK_CLIENT_ID)</small></td>
+                                <td><code>{{ system_info.keycloak_client_id }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Redirect URL <small class="fw-normal text-muted">(KEYCLOAK_REDIRECT_URL)</small></td>
+                                <td><code style="font-size: 0.85em;">{{ system_info.keycloak_redirect_url }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Group admin <small class="fw-normal text-muted">(KEYCLOAK_GROUP_ADMIN)</small></td>
+                                <td><code>{{ system_info.keycloak_group_admin }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Group editor <small class="fw-normal text-muted">(KEYCLOAK_GROUP_EDITOR)</small></td>
+                                <td><code>{{ system_info.keycloak_group_editor }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Group read only <small class="fw-normal text-muted">(KEYCLOAK_GROUP_READONLY)</small></td>
+                                <td><code>{{ system_info.keycloak_group_readonly }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Group case admin <small class="fw-normal text-muted">(KEYCLOAK_GROUP_CASE_ADMIN)</small></td>
+                                <td><code>{{ system_info.keycloak_group_case_admin }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Role case admin <small class="fw-normal text-muted">(KEYCLOAK_ROLE_CASE_ADMIN)</small></td>
+                                <td><code>{{ system_info.keycloak_role_case_admin }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Group queue admin <small class="fw-normal text-muted">(KEYCLOAK_GROUP_QUEUE_ADMIN)</small></td>
+                                <td><code>{{ system_info.keycloak_group_queue_admin }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Role queue admin <small class="fw-normal text-muted">(KEYCLOAK_ROLE_QUEUE_ADMIN)</small></td>
+                                <td><code>{{ system_info.keycloak_role_queue_admin }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Group queuer <small class="fw-normal text-muted">(KEYCLOAK_GROUP_QUEUER)</small></td>
+                                <td><code>{{ system_info.keycloak_group_queuer }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold"><small class="text-danger fw-bold">CLI</small> Role queuer <small class="fw-normal text-muted">(KEYCLOAK_ROLE_QUEUER)</small></td>
+                                <td><code>{{ system_info.keycloak_role_queuer }}</code></td>
+                            </tr>
+                            {% endif %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
             <!-- ── MISP integration ── -->
             <div class="card mb-4" style="box-shadow: 0.1rem 0.3rem 0.5rem rgba(0, 0, 0, 0.1);">
                 <div class="card-header py-3">

--- a/app/tools/tools.py
+++ b/app/tools/tools.py
@@ -628,6 +628,22 @@ def system_settings():
         'entra_role_queuer': current_app.config.get('ENTRA_ROLE_QUEUER', ''),
         'entra_redirect_url': current_app.config.get('ENTRA_REDIRECT_URL', ''),
 
+        # Keycloak SSO
+        'keycloak_enabled': current_app.config.get('KEYCLOAK_ENABLED', False),
+        'keycloak_base_url': current_app.config.get('KEYCLOAK_BASE_URL', ''),
+        'keycloak_realm': current_app.config.get('KEYCLOAK_REALM', ''),
+        'keycloak_client_id': current_app.config.get('KEYCLOAK_CLIENT_ID', ''),
+        'keycloak_group_admin': current_app.config.get('KEYCLOAK_GROUP_ADMIN', ''),
+        'keycloak_group_editor': current_app.config.get('KEYCLOAK_GROUP_EDITOR', ''),
+        'keycloak_group_readonly': current_app.config.get('KEYCLOAK_GROUP_READONLY', ''),
+        'keycloak_group_case_admin': current_app.config.get('KEYCLOAK_GROUP_CASE_ADMIN', ''),
+        'keycloak_role_case_admin': current_app.config.get('KEYCLOAK_ROLE_CASE_ADMIN', ''),
+        'keycloak_group_queue_admin': current_app.config.get('KEYCLOAK_GROUP_QUEUE_ADMIN', ''),
+        'keycloak_role_queue_admin': current_app.config.get('KEYCLOAK_ROLE_QUEUE_ADMIN', ''),
+        'keycloak_group_queuer': current_app.config.get('KEYCLOAK_GROUP_QUEUER', ''),
+        'keycloak_role_queuer': current_app.config.get('KEYCLOAK_ROLE_QUEUER', ''),
+        'keycloak_redirect_url': current_app.config.get('KEYCLOAK_REDIRECT_URL', ''),
+
         # Database
         'db_type': db_type,
         'db_name': db_name,

--- a/conf/config.py.default
+++ b/conf/config.py.default
@@ -167,6 +167,29 @@ class Config:
     ENTRA_REDIRECT_URL = os.getenv('ENTRA_REDIRECT_URL', 'http://localhost:7006/account/entra/callback')
 
     # =============================================================================
+    # KEYCLOAK
+    # =============================================================================
+    # Keycloak SSO configuration
+    KEYCLOAK_ENABLED = os.getenv('KEYCLOAK_ENABLED', 'false').lower() == 'true'
+    KEYCLOAK_BASE_URL = os.getenv('KEYCLOAK_BASE_URL', '')       # e.g. https://keycloak.example.com
+    KEYCLOAK_REALM = os.getenv('KEYCLOAK_REALM', 'flowintel')
+    KEYCLOAK_CLIENT_ID = os.getenv('KEYCLOAK_CLIENT_ID', 'flowintel')
+    KEYCLOAK_CLIENT_SECRET = os.getenv('KEYCLOAK_CLIENT_SECRET', '')
+
+    # Keycloak group names that map to Flowintel roles
+    # FlowintelAdmin members → provisioned as Editor, admins are notified to promote manually
+    KEYCLOAK_GROUP_ADMIN = os.getenv('KEYCLOAK_GROUP_ADMIN', 'FlowintelAdmin')
+    KEYCLOAK_GROUP_EDITOR = os.getenv('KEYCLOAK_GROUP_EDITOR', 'FlowintelEditor')
+    KEYCLOAK_GROUP_READONLY = os.getenv('KEYCLOAK_GROUP_READONLY', 'FlowintelReadOnly')
+    KEYCLOAK_GROUP_CASE_ADMIN  = os.getenv('KEYCLOAK_GROUP_CASE_ADMIN',  'FlowintelCaseAdmin')
+    KEYCLOAK_ROLE_CASE_ADMIN   = os.getenv('KEYCLOAK_ROLE_CASE_ADMIN',   'CaseAdmin')
+    KEYCLOAK_GROUP_QUEUE_ADMIN = os.getenv('KEYCLOAK_GROUP_QUEUE_ADMIN', 'FlowintelQueueAdmin')
+    KEYCLOAK_ROLE_QUEUE_ADMIN  = os.getenv('KEYCLOAK_ROLE_QUEUE_ADMIN',  'QueueAdmin')
+    KEYCLOAK_GROUP_QUEUER      = os.getenv('KEYCLOAK_GROUP_QUEUER',      'FlowintelQueuer')
+    KEYCLOAK_ROLE_QUEUER       = os.getenv('KEYCLOAK_ROLE_QUEUER',       'Queuer')
+    KEYCLOAK_REDIRECT_URL = os.getenv('KEYCLOAK_REDIRECT_URL', 'http://localhost:7006/account/keycloak/callback')
+
+    # =============================================================================
     # MISP INTEGRATION
     # =============================================================================
     # MISP connector: attach case & task files to the MISP event

--- a/doc/installation-manual.md
+++ b/doc/installation-manual.md
@@ -1032,9 +1032,171 @@ ENTRA_ROLE_QUEUER=Queuer
 
 When Entra ID SSO is enabled (`ENTRA_ID_ENABLED=true`), a **Sign in with Microsoft** button appears on the Flowintel login page. The first time a user signs in through SSO, Flowintel automatically creates a local account for them based on their Entra ID profile.
 
-Users whose highest-priority group is `FlowintelAdmin` are initially created with the **Editor** role rather than Admin. This is a deliberate safeguard: it ensures that no one receives full administrative access automatically, reducing the risk of accidental privilege escalation. All existing Flowintel administrators receive a notification so they can review the new account and promote the user to Admin once they have verified the request is legitimate.
+Users whose highest-priority group is `FlowintelAdmin` are initially created with the **Editor** role rather than Admin. This is a deliberate safeguard: it ensures that no one receives full administrative access automatically, reducing the risk of accidental privilege escalation.
+
+All existing Flowintel administrators receive a notification whenever a new SSO account is created. For users in the Admin group, the notification asks administrators to promote the user if appropriate. For all other users, the notification asks administrators to review the user's organisation assignment. New SSO users are placed in a personal organisation by default, so administrators may want to move them to a shared organisation.
 
 SSO accounts rely entirely on the organisation's Microsoft account for authentication. This means they cannot use the local password reset feature or change the email address associated with their Flowintel account. Administrators can still edit SSO user accounts through the web interface, for example to change a user's role or organisation, but they cannot set a local password for them.
+
+## Keycloak SSO (optional)
+
+Flowintel supports single sign-on via Keycloak. When enabled, users can sign in with their Keycloak account instead of a local password. Local accounts still work alongside SSO. The Keycloak integration follows the same role-mapping model as the Entra ID integration described above.
+
+### Keycloak server prerequisites
+
+You need a running Keycloak instance (version 20 or later) before configuring Flowintel. The examples below assume Keycloak is reachable at `https://keycloak.your-org-keycloak.com`. Replace this with the address of your own Keycloak server.
+
+### Create a realm
+
+If you do not already have a dedicated realm for Flowintel, create one:
+
+1. Open the Keycloak admin console at `https://keycloak.your-org-keycloak.com/admin/`
+2. In the top-left realm dropdown, click **Create realm**
+3. Set the **Realm name** to `flowintel`
+4. Make sure **Enabled** is on, then click **Create**
+
+All the steps below are carried out inside this `flowintel` realm.
+
+### Create an OpenID Connect client
+
+1. In the Keycloak admin console, go to **Clients → Create client**
+2. Set **Client type** to `OpenID Connect`
+3. Set **Client ID** to `flowintel` (you can pick a different name, but take note of it for the Flowintel configuration later)
+4. Click **Next**
+5. On the Capability config step:
+   - Enable **Client authentication** (this makes it a confidential client)
+   - Ensure **Standard flow** is enabled (Authorization Code flow)
+   - Disable **Direct access grants** unless you need them for testing
+6. Click **Next**
+7. On the Login settings step, configure the redirect URI:
+   ```
+   https://flowintel.yourdomain.com/account/keycloak/callback
+   ```
+   Set **Valid post logout redirect URIs** to:
+   ```
+   https://flowintel.yourdomain.com/*
+   ```
+   Set **Web origins** to:
+   ```
+   https://flowintel.yourdomain.com
+   ```
+8. Click **Save**
+
+After saving, go to the **Credentials** tab and copy the **Client secret**. You will need it when configuring Flowintel.
+
+Note down the following values:
+
+| Value | Where to find it | Example |
+|---|---|---|
+| Realm name | Top-left dropdown | `flowintel` |
+| Client ID | Clients → flowintel → Settings | `flowintel` |
+| Client secret | Clients → flowintel → Credentials | `AbCdEf...` |
+| Keycloak base URL | Your Keycloak address | `https://keycloak.your-org-keycloak.com` |
+
+### Create groups for role mapping
+
+Flowintel uses Keycloak group membership to assign roles, in the same way as it uses Entra ID groups. Create the following groups in your realm:
+
+1. In the Keycloak admin console, go to **Groups → Create group**
+2. Create each of the following groups:
+
+| Keycloak group | Flowintel role | Notes |
+|---|---|---|
+| `FlowintelAdmin` | Editor | Account is created as **Editor**; all admins receive a notification to promote the user to Admin manually |
+| `FlowintelEditor` | Editor | Standard analyst access |
+| `FlowintelCaseAdmin` | CaseAdmin | Can manage cases and approve tasks |
+| `FlowintelQueueAdmin` | QueueAdmin | Can manage queues and approve tasks |
+| `FlowintelQueuer` | Queuer | Can submit tasks for approval in privileged cases |
+| `FlowintelReadOnly` | Read Only | View-only access |
+
+When a user signs in for the first time, Flowintel checks their group memberships in the order listed above. The first matching group determines their role. Users not in any of these groups are denied access.
+
+### Assign users to groups
+
+1. Go to **Users** in the Keycloak admin console
+2. Select a user (or create one)
+3. Go to the **Groups** tab
+4. Click **Join Group** and select the appropriate Flowintel group
+
+### Add a group membership mapper
+
+Keycloak does not include group information in tokens by default. You need to add a client scope mapper so that Flowintel can read the user's groups from the token.
+
+1. Go to **Clients** in the left menu, then click on your `flowintel` client
+2. Go to the **Client scopes** tab
+3. Click on the `flowintel-dedicated` scope. Keycloak creates this scope automatically when you create a client, and names it `<client-id>-dedicated`. If you do not see it in the list, click **Add client scope**, select **flowintel-dedicated**, and add it as a **Default** scope. If no dedicated scope exists at all, you can create one manually: go to **Client scopes** in the left menu, click **Create client scope**, name it `flowintel-dedicated`, set the type to **Default**, and then assign it to your client from the client's **Client scopes** tab.
+4. Click **Configure a new mapper**
+4. Select **Group Membership**
+5. Configure the mapper:
+   - **Name**: `groups`
+   - **Token Claim Name**: `groups`
+   - **Full group path**: **OFF** (Flowintel expects flat group names, not paths like `/FlowintelAdmin`)
+   - **Add to ID token**: **ON**
+   - **Add to access token**: **ON**
+   - **Add to userinfo**: **ON**
+6. Click **Save**
+
+With this mapper in place, every token issued for the Flowintel client will include a `groups` claim with the user's group names.
+
+### Verify the token contains groups
+
+Before moving on to Flowintel, it is worth checking that the token contains the expected claims. In the Keycloak admin console:
+
+1. Go to **Clients → flowintel → Client scopes**
+2. Click **Evaluate**
+3. Select a user who is a member of one of the Flowintel groups
+4. Click **Generated ID token**
+5. Confirm the JSON contains:
+   - `preferred_username` or `email`
+   - `given_name` and `family_name` (or `name`). If these are empty, open the user in **Users**, fill in **First name** and **Last name**, and save. Keycloak does not require these fields when creating a user, but Flowintel needs them to set up the local account.
+   - `groups` array with the user's group names, for example `["FlowintelEditor"]`
+
+If the `groups` claim is missing, check that the mapper from the previous step is correctly configured and assigned to the `flowintel-dedicated` scope.
+
+### Flowintel configuration for Keycloak
+
+Add the following to your `.env` file (or set the equivalent environment variables):
+
+```bash
+# Keycloak SSO
+KEYCLOAK_ENABLED=true
+KEYCLOAK_BASE_URL=https://keycloak.your-org-keycloak.com
+KEYCLOAK_REALM=flowintel
+KEYCLOAK_CLIENT_ID=flowintel
+KEYCLOAK_CLIENT_SECRET=<your-client-secret>
+KEYCLOAK_REDIRECT_URL=https://flowintel.yourdomain.com/account/keycloak/callback
+```
+
+The `KEYCLOAK_REDIRECT_URL` must exactly match the redirect URI registered in Keycloak, including the scheme (`https://`). If Flowintel runs behind a reverse proxy, make sure this URL reflects the public-facing address rather than the internal `127.0.0.1` address.
+
+The group and role name mappings can be customised if your Keycloak groups are named differently:
+
+```bash
+# Keycloak group names
+KEYCLOAK_GROUP_ADMIN=FlowintelAdmin
+KEYCLOAK_GROUP_EDITOR=FlowintelEditor
+KEYCLOAK_GROUP_READONLY=FlowintelReadOnly
+KEYCLOAK_GROUP_CASE_ADMIN=FlowintelCaseAdmin
+KEYCLOAK_GROUP_QUEUE_ADMIN=FlowintelQueueAdmin
+KEYCLOAK_GROUP_QUEUER=FlowintelQueuer
+
+# Flowintel role names for the custom roles
+KEYCLOAK_ROLE_CASE_ADMIN=CaseAdmin
+KEYCLOAK_ROLE_QUEUE_ADMIN=QueueAdmin
+KEYCLOAK_ROLE_QUEUER=Queuer
+```
+
+### SSO behaviour
+
+When Keycloak SSO is enabled (`KEYCLOAK_ENABLED=true`), a **Sign in with Keycloak** button appears on the Flowintel login page. The first time a user signs in through SSO, Flowintel automatically creates a local account for them based on their Keycloak profile.
+
+Users whose highest-priority group is `FlowintelAdmin` are initially created with the **Editor** role rather than Admin. This is intentional: no one should receive full administrative access automatically.
+
+All existing Flowintel administrators receive a notification whenever a new SSO account is created. For users in the Admin group, the notification asks administrators to promote the user if appropriate. For all other users, the notification asks administrators to review the user's organisation assignment. New SSO users are placed in a personal organisation by default, so administrators may want to move them to a shared organisation.
+
+SSO accounts rely on the organisation's Keycloak instance for authentication. Users who sign in through Keycloak cannot use the local password reset feature or change the email address on their Flowintel account. Administrators can still edit SSO user accounts through the web interface, for example to change a user's role or organisation, but cannot set a local password for them.
+
+Flowintel synchronises roles on every SSO login. If a user's Keycloak group membership changes, their Flowintel role is updated the next time they sign in. If you manually promote an SSO user to a higher role within Flowintel, that change will be overwritten at their next login unless their Keycloak group membership has also been updated.
 
 ## GPG report signing (optional)
 
@@ -2002,6 +2164,16 @@ sudo nginx -t && sudo systemctl reload nginx
    mkdir -p /opt/flowintel/flowintel/uploads
    chmod 755 /opt/flowintel/flowintel/uploads
    ```
+
+## Keycloak SSO
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Redirect fails after clicking "Sign in with Keycloak" | `KEYCLOAK_REDIRECT_URL` does not match the URI registered in Keycloak | Ensure the URLs are identical, including trailing slashes and scheme |
+| User denied access despite being in a group | `groups` claim missing from the token | Add the Group Membership mapper as described in the Keycloak SSO section and set **Full group path** to OFF |
+| Token contains `/FlowintelEditor` instead of `FlowintelEditor` | **Full group path** is enabled in the mapper | Edit the mapper and set **Full group path** to OFF |
+| "Invalid client" error | Client authentication is disabled or wrong secret | Check the Credentials tab in Keycloak and verify `KEYCLOAK_CLIENT_SECRET` |
+| SSO works but user gets the wrong role | User is in multiple groups | The highest-priority group wins; check the group priority table in the Keycloak SSO section |
 
 ## General troubleshooting steps
 

--- a/doc/user-manual.md
+++ b/doc/user-manual.md
@@ -1694,7 +1694,7 @@ When a user clicks **Sign in with Microsoft**, they are redirected to the Micros
 
 Entra ID group membership determines the user's role. The administrator maps Entra ID groups to Flowintel roles in the server configuration. The mapping follows a priority order: Admin, Editor, Case Admin, Queue Admin, Queuer, then Read Only. A user who belongs to multiple groups receives the highest-priority role. If a user is not a member of any mapped group, login is denied.
 
-Because Flowintel creates accounts automatically on first SSO login, there is no need for the administrator to create user records in advance. New users are assigned to the default organisation and receive the role that matches their Entra ID group membership. Administrators are notified when a user in the Admin group logs in for the first time, so they can review the account.
+Because Flowintel creates accounts automatically on first SSO login, there is no need for the administrator to create user records in advance. New users are placed in a personal organisation and receive the role that matches their Entra ID group membership. Administrators are notified whenever a new SSO user is created, so they can review the account and move the user to the appropriate shared organisation if needed.
 
 SSO and local authentication can coexist. Users who do not have a Microsoft account can still log in with their email and password. SSO configuration, including the Azure tenant ID, client ID, client secret and group mappings, is managed in the server configuration file (`conf/config.py`). Refer to the [installation manual](installation-manual.md) for detailed setup instructions.
 

--- a/template.env
+++ b/template.env
@@ -30,3 +30,20 @@ FLASK_ENV="production"
 # ENTRA_ROLE_QUEUE_ADMIN=QueueAdmin
 # ENTRA_GROUP_QUEUER=FlowintelQueuer
 # ENTRA_ROLE_QUEUER=Queuer
+
+# Keycloak SSO (optional)
+# KEYCLOAK_ENABLED=true
+# KEYCLOAK_BASE_URL=https://keycloak.your-org-keycloak.com
+# KEYCLOAK_REALM=flowintel
+# KEYCLOAK_CLIENT_ID=flowintel
+# KEYCLOAK_CLIENT_SECRET=<your-client-secret>
+# KEYCLOAK_REDIRECT_URL=https://<your-flowintel-host>/account/keycloak/callback
+# KEYCLOAK_GROUP_ADMIN=FlowintelAdmin
+# KEYCLOAK_GROUP_EDITOR=FlowintelEditor
+# KEYCLOAK_GROUP_READONLY=FlowintelReadOnly
+# KEYCLOAK_GROUP_CASE_ADMIN=FlowintelCaseAdmin
+# KEYCLOAK_ROLE_CASE_ADMIN=CaseAdmin
+# KEYCLOAK_GROUP_QUEUE_ADMIN=FlowintelQueueAdmin
+# KEYCLOAK_ROLE_QUEUE_ADMIN=QueueAdmin
+# KEYCLOAK_GROUP_QUEUER=FlowintelQueuer
+# KEYCLOAK_ROLE_QUEUER=Queuer


### PR DESCRIPTION
- Add Keycloak SSO login flow
- Align Entra ID name extraction with Keycloak
- Update login page, user edit forms, and system settings for Keycloak
- Always notify admins when any SSO user is provisioned (Keycloak and EntraID)
- Block password reset requests for SSO-managed accounts
- Add Keycloak configuration to config.py.default and template.env
- Add Keycloak SSO setup documentation in installation-manual.md


**Keycloak SSO settings**
<img width="705" height="774" alt="image" src="https://github.com/user-attachments/assets/3bd5dc01-fa23-4044-93a7-af06632abc9f" />

**Sign in with Keycloak**
<img width="377" height="489" alt="image" src="https://github.com/user-attachments/assets/c85a11d9-2a79-4a9f-a02b-3b0f0e11c069" />

**Block login/pw edits for SSO accounts**
<img width="1005" height="360" alt="image" src="https://github.com/user-attachments/assets/26edfec1-0264-4ac4-90af-b3ad70ccba20" />
