### PR TITLE
fix/uc-13_misp_editor_permissions

### DIFF
--- a/app/analyzer/analyzer_api.py
+++ b/app/analyzer/analyzer_api.py
@@ -2,7 +2,7 @@ from flask import request, jsonify
 from ..utils.utils import get_user_from_api
 
 from flask_restx import Namespace, Resource
-from ..decorators import api_required, editor_required
+from ..decorators import api_required, misp_editor_required
 from . import session_class as SessionModel
 from . import misp_modules_core as MispModuleModel
 
@@ -12,7 +12,7 @@ analyzer_ns = Namespace("analyzer", description="Endpoints to manage analyzer")
 @analyzer_ns.route('/misp-modules/query', methods=['POST'])
 @analyzer_ns.doc(description='Receive a result from an external tool')
 class Query(Resource):
-    method_decorators = [editor_required, api_required]
+    method_decorators = [misp_editor_required, api_required]
     @analyzer_ns.doc(params={
         "query": "Required. List of queries",
         "input": "Required. Type of attributes in entry.Can be only one type",

--- a/app/analyzer/misp_modules.py
+++ b/app/analyzer/misp_modules.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, redirect, render_template, request, session as flask_session
 from flask_login import current_user, login_required
-from ..decorators import editor_required
+from ..decorators import misp_editor_required
 from ..utils.logger import flowintel_log
 from . import session_class as SessionModel
 from . import misp_modules_core as MispModuleModel
@@ -19,7 +19,6 @@ analyzer_blueprint = Blueprint(
 
 @analyzer_blueprint.route("/misp-modules", methods=['GET'])
 @login_required
-@editor_required
 def index():
     """Analyzer index page"""
     case_id = ""
@@ -31,11 +30,12 @@ def index():
         task_id = request.args.get('task_id')
     if "misp_object" in request.args:
         misp_object = True
-    return render_template("analyzer/misp_modules_index.html", case_id=case_id, task_id=task_id, misp_object=misp_object)
+    can_use_misp = current_user.is_admin() or current_user.is_misp_editor()
+    return render_template("analyzer/misp_modules_index.html", case_id=case_id, task_id=task_id, misp_object=misp_object, can_use_misp=can_use_misp)
 
 @analyzer_blueprint.route("/misp-modules/result_to_case", methods=['GET', 'POST'])
 @login_required
-@editor_required
+@misp_editor_required
 def result_to_case():
     """Enrich notes from previous selection"""
     flask_session["note_selected"] = request.form["note_selected"]
@@ -58,7 +58,7 @@ def get_misp_object_selected():
 
 @analyzer_blueprint.route("/misp-modules/manage_notes_selected", methods=['GET', 'POST'])
 @login_required
-@editor_required
+@misp_editor_required
 def manage_notes_selected():
     """Manage notes selected"""
     case_id = MispModuleModel.manage_notes_selected(request.json, current_user)
@@ -95,7 +95,7 @@ def get_modules():
 
 @analyzer_blueprint.route("/misp-modules/run", methods=['POST'])
 @login_required
-@editor_required
+@misp_editor_required
 def run_misp_modules():
     """Run modules"""
     if "query" in request.json:
@@ -123,12 +123,14 @@ def run_misp_modules():
 
 @analyzer_blueprint.route("/misp-modules/config", methods=['GET'])
 @login_required
+@misp_editor_required
 def misp_modules_config():
     """Configure misp-modules"""
     return render_template("analyzer/misp_modules_config.html")
 
 @analyzer_blueprint.route("/misp-modules/modules_config_data")
 @login_required
+@misp_editor_required
 def modules_config_data():
     """List all modules for configuration"""
 
@@ -141,6 +143,7 @@ def modules_config_data():
 
 @analyzer_blueprint.route("/misp-modules/change_config", methods=["POST"])
 @login_required
+@misp_editor_required
 def misp_modules_change_config():
     """Change configuation for a misp-module"""
     if "module_name" in request.json["result_dict"]:
@@ -201,12 +204,14 @@ def misp_module_result(sid):
 
 @analyzer_blueprint.route("/misp-modules/history", methods=['GET'])
 @login_required
+@misp_editor_required
 def misp_modules_history():
     """History of misp-modules"""
     return render_template("analyzer/misp_modules_history.html")
 
 @analyzer_blueprint.route("/misp-modules/history_data", methods=['GET'])
 @login_required
+@misp_editor_required
 def misp_modules_history_data():
     """Get all history"""
     page = request.args.get('page', 1, type=int)
@@ -215,6 +220,7 @@ def misp_modules_history_data():
 
 @analyzer_blueprint.route("/misp-modules/delete_history/<huuid>", methods=['GET'])
 @login_required
+@misp_editor_required
 def misp_modules_delete_history(huuid):
     """Delete history"""
     if MispModuleModel.delete_history(huuid, current_user):

--- a/app/templates/analyzer/misp_modules_index.html
+++ b/app/templates/analyzer/misp_modules_index.html
@@ -20,18 +20,33 @@
                 <h5 class="mb-0"><i class="fa-solid fa-puzzle-piece me-2"></i>Analyser - MISP modules</h5>
             </div>
             <div class="col-auto ms-auto">
+                {% if can_use_misp %}
                 <a class="btn btn-outline-primary btn-sm" href="/analyzer/misp-modules/history">
                     <i class="fa-solid fa-clock-rotate-left fa-sm"></i> History
                 </a>
                 <a class="btn btn-outline-primary btn-sm ms-2" href="/analyzer/misp-modules/config">
                     <i class="fa-solid fa-gear fa-sm"></i> Config
                 </a>
+                {% else %}
+                <button class="btn btn-outline-primary btn-sm" disabled title="Access Restricted: You need Admin or MISP Editor permission to use connectors.">
+                    <i class="fa-solid fa-clock-rotate-left fa-sm"></i> History
+                </button>
+                <button class="btn btn-outline-primary btn-sm ms-2" disabled title="Access Restricted: You need Admin or MISP Editor permission to use connectors.">
+                    <i class="fa-solid fa-gear fa-sm"></i> Config
+                </button>
+                {% endif %}
             </div>
         </div>
         <p class="text-muted mb-0 mt-1">The MISP module analyser allows you to use external enrichment modules. Be aware of any PAP restrictions that apply as you can be sending data to external services.</p>
     </div>
     <hr>
 
+    {% if not can_use_misp %}
+    <div class="alert alert-warning" role="alert">
+        <i class="fa-solid fa-lock me-2"></i>
+        <strong>Access Restricted:</strong> You need Admin or MISP Editor permission to use connectors.
+    </div>
+    {% else %}
     {% set active_phase = 1 %}
     {% include 'analyzer/misp_modules_phase_indicator.html' %}
 
@@ -174,10 +189,12 @@
         
     </div>
     <div id="insert_form"></div>
+    {% endif %}
 {% endblock %}
 
 
 {% block script %}
+    {% if can_use_misp %}
     <script type="module">
         const { createApp, ref, onMounted, nextTick } = Vue
         import {display_toast, message_list, create_message} from '/static/js/toaster.js'
@@ -455,4 +472,5 @@
         }).mount('#main-container')
 
     </script>
+    {% endif %}
 {% endblock %}

--- a/app/templates/case/case_view.html
+++ b/app/templates/case/case_view.html
@@ -265,7 +265,7 @@
         </li>
         <li class="nav-item">
             <button class="nav-link" id="tab-misp-objects" @click="active_tab('misp-objects')">
-                <i class="fa-solid fa-cubes fa-sm me-1"></i><span class="section-title fs-6">MISP objects </span> 
+                <i v-if="!can_use_connectors" class="fa-solid fa-lock me-1"></i><i class="fa-solid fa-cubes fa-sm me-1"></i><span class="section-title fs-6">MISP objects </span> 
                 <span class="badge text-bg-secondary d-none" id="id-nb-misp-object">[[nb_misp_objects]]</span>
             </button>
         </li>
@@ -498,7 +498,11 @@
         </template>
 
         <template v-else-if="main_tab == 'misp-objects'">
-            <misp_object :case_id="{{case.id}}" :cases_info="cases_info" @modif_misp_objects="(msg) => fetch_nb_misp_objects()"></misp_object>
+            <div v-if="!can_use_connectors" class="alert alert-warning" role="alert">
+                <i class="fa-solid fa-lock me-2"></i>
+                <strong>Access Restricted:</strong> You need Admin or MISP Editor permission to use connectors.
+            </div>
+            <misp_object v-else :case_id="{{case.id}}" :cases_info="cases_info" @modif_misp_objects="(msg) => fetch_nb_misp_objects()"></misp_object>
         </template>
 
         <template v-else-if="main_tab == 'connectors'">

--- a/app/templates/tools/case_misp_event.html
+++ b/app/templates/tools/case_misp_event.html
@@ -12,6 +12,14 @@
 
     <hr class="fading-line-2 mt-4 mb-4">
 
+    {% if not can_use_misp %}
+    <div class="container-fluid w-75">
+        <div class="alert alert-warning" role="alert">
+            <i class="fa-solid fa-lock me-2"></i>
+            <strong>Access Restricted:</strong> You need Admin or MISP Editor permission to use connectors.
+        </div>
+    </div>
+    {% else %}
     <div class="container-fluid w-75 case-core-style">
         <div class="row mt-5">
             <div class="col">
@@ -76,11 +84,13 @@
             <span v-else>Submit</span>
         </button>
     </div>
+    {% endif %}
 
 {% endblock %}
 
 
 {% block script %}
+    {% if can_use_misp %}
     <script type="module">
         const { createApp, ref, onMounted } = Vue
         import {display_toast, message_list} from '/static/js/toaster.js'
@@ -227,4 +237,5 @@
         }).mount('#main-container')
 
     </script>
+    {% endif %}
 {% endblock %}

--- a/app/tools/tools.py
+++ b/app/tools/tools.py
@@ -2,7 +2,7 @@ from flask import Blueprint, abort, flash, jsonify, redirect, render_template, r
 from flask_login import login_required, current_user
 from . import tools_core as ToolsModel
 from ..utils.note_variables import get_syntax_reference
-from ..decorators import editor_required, admin_required, template_editor_required
+from ..decorators import editor_required, admin_required, template_editor_required, misp_editor_required
 from ..utils.utils import get_modules_list, reload_application
 from ..utils.logger import flowintel_log
 from ..case.common_core import get_all_cases as common_get_all_cases, get_case as common_get_case
@@ -450,21 +450,23 @@ def delete_note_template(nid):
 
 @tools_blueprint.route("/case_misp_event", methods=["GET", "POST"])
 @login_required
-@editor_required
 def case_misp_event():
+    can_use_misp = current_user.is_admin() or current_user.is_misp_editor()
     if request.method == 'POST':
+        if not can_use_misp:
+            return {"message": "Action not Allowed", "toast_class": "warning-subtle"}, 403
         res = ToolsModel.check_case_misp_event(request.json, current_user)
         if not type(res) == str:
             case = ToolsModel.create_case_misp_event(request.json, current_user)
             return {"case_id": case.id}, 200
         else:
             return {"message": res, "toast_class": "warning-subtle"}, 400
-    return render_template("tools/case_misp_event.html")
+    return render_template("tools/case_misp_event.html", can_use_misp=can_use_misp)
 
 
 @tools_blueprint.route("/check_connection", methods=["GET"])
 @login_required
-@editor_required
+@misp_editor_required
 def check_connection():
     misp_instance_id = request.args.get('misp_instance_id', 1, type=int)
     res = ToolsModel.check_connection_misp(misp_instance_id, current_user)
@@ -474,7 +476,7 @@ def check_connection():
 
 @tools_blueprint.route("/check_misp_event", methods=["GET"])
 @login_required
-@editor_required
+@misp_editor_required
 def check_misp_event():
     misp_instance_id = request.args.get('misp_instance_id', 1, type=int)
     misp_event_id = request.args.get('misp_event_id', 1, type=str)

--- a/app/tools/tools_api.py
+++ b/app/tools/tools_api.py
@@ -2,7 +2,7 @@ from flask import request
 from . import tools_core as ToolModel
 
 from flask_restx import Namespace, Resource
-from ..decorators import api_required, importer_required, template_editor_required
+from ..decorators import api_required, importer_required, template_editor_required, misp_editor_required
 
 from ..utils import utils
 from ..utils.logger import flowintel_log
@@ -62,7 +62,7 @@ case_misp_ns = Namespace("case_misp", description="Endpoints to manage case crea
 @case_misp_ns.route('/')
 @case_misp_ns.doc(description='Create a Case from a MISP Event')
 class CaseMispEvent(Resource):
-    method_decorators = [api_required]
+    method_decorators = [misp_editor_required, api_required]
     @case_misp_ns.doc(params={
         "case_title": "Required. Title for the new case",
         "case_template_id": "Required. Id of a case template",


### PR DESCRIPTION
- Correct the locations where misp editor permissions are required
- Connectors where already protected, but misp objects not yet
- Limited access to analyser (same as 'misp objects') to misp editor as well
- Same goes for creating a case from a MISP event