### PR TITLE
fix/user-permissions 

### DIFF
--- a/app/case/case.py
+++ b/app/case/case.py
@@ -939,6 +939,10 @@ def get_computer_assistate_report(cid):
     """Create a report from all case information"""
     case = CommonModel.get_case(cid)
     if case:
+        if not check_user_private_case(case):
+            flowintel_log("audit", 403, "Get computer assisted report: Private case: Permission denied", User=current_user.email, CaseId=cid)
+            return {"message": "Permission denied", 'toast_class': "danger-subtle"}, 403
+
         flowintel_log("audit", 200, "Get computer assisted report", User=current_user.email, CaseId=cid)
 
         resp = {"report": case.computer_assistate_report}
@@ -1043,10 +1047,11 @@ def download_file(cid):
     """Download the file"""
     case = CommonModel.get_case(cid)
     if case:
-        if CommonModel.get_present_in_case(cid, current_user) or current_user.is_admin():
-            flowintel_log("audit", 200, "Download case history", User=current_user.email, CaseId=cid)
-            return CaseModel.download_history(case)
-        return {"message": "Action not allowed", "toast_class": "warning-subtle"}, 403
+        if not check_user_private_case(case):
+            flowintel_log("audit", 403, "Download case history: Private case: Permission denied", User=current_user.email, CaseId=cid)
+            return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        flowintel_log("audit", 200, "Download case history", User=current_user.email, CaseId=cid)
+        return CaseModel.download_history(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
 
 
@@ -1056,10 +1061,11 @@ def download_history_md(cid):
     """Download the file"""
     case = CommonModel.get_case(cid)
     if case:
-        if CommonModel.get_present_in_case(cid, current_user) or current_user.is_admin():
-            flowintel_log("audit", 200, "Download case markdown", User=current_user.email, CaseId=cid)
-            return CaseModel.download_history_md(case)
-        return {"message": "Action not allowed", "toast_class": "warning-subtle"}, 403
+        if not check_user_private_case(case):
+            flowintel_log("audit", 403, "Download case markdown: Private case: Permission denied", User=current_user.email, CaseId=cid)
+            return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        flowintel_log("audit", 200, "Download case markdown", User=current_user.email, CaseId=cid)
+        return CaseModel.download_history_md(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
 
 
@@ -1069,9 +1075,11 @@ def download_audit_logs(cid):
     """Download the audit logs as text file"""
     case = CommonModel.get_case(cid)
     if case:
-        if CommonModel.get_present_in_case(cid, current_user) or current_user.is_admin():
-            return CommonModel.download_audit_logs(case)
-        return {"message": "Action not allowed", "toast_class": "warning-subtle"}, 403
+        if not check_user_private_case(case):
+            flowintel_log("audit", 403, "Download audit logs: Private case: Permission denied", User=current_user.email, CaseId=cid)
+            return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        flowintel_log("audit", 200, "Download audit logs", User=current_user.email, CaseId=cid)
+        return CommonModel.download_audit_logs(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
 
 
@@ -1081,9 +1089,11 @@ def download_audit_logs_md(cid):
     """Download the audit logs as markdown file"""
     case = CommonModel.get_case(cid)
     if case:
-        if CommonModel.get_present_in_case(cid, current_user) or current_user.is_admin():
-            return CommonModel.download_audit_logs_md(case)
-        return {"message": "Action not allowed", "toast_class": "warning-subtle"}, 403
+        if not check_user_private_case(case):
+            flowintel_log("audit", 403, "Download audit logs markdown: Private case: Permission denied", User=current_user.email, CaseId=cid)
+            return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        flowintel_log("audit", 200, "Download audit logs markdown", User=current_user.email, CaseId=cid)
+        return CommonModel.download_audit_logs_md(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
 
 @case_blueprint.route("/<cid>/add_new_link", methods=['GET', 'POST'])
@@ -1188,6 +1198,11 @@ def get_case_misp_object(cid):
 @case_blueprint.route("/<int:cid>/get_correlation_attr/<int:aid>", methods=['GET'])
 @login_required
 def get_correlation_attr(cid, aid):
+    case = CommonModel.get_case(cid)
+    if not case:
+        return {"correlation_list": []}, 200
+    if not check_user_private_case(case):
+        return {"correlation_list": []}, 200
     attribute = CaseModel.get_misp_attribute(aid)
     res = CaseModel.check_correlation_attr(cid, attribute)
     return {"correlation_list": res}, 200

--- a/app/connectors/connectors_api.py
+++ b/app/connectors/connectors_api.py
@@ -5,6 +5,7 @@ from ..decorators import api_required, admin_required, misp_editor_required
 from . import connectors_core as ConnectorModel
 from . import connectors_core_api as ConnectorModelApi
 from ..utils import utils
+from ..utils.logger import flowintel_log
 
 connectors_ns = Namespace("connectors", description="Endpoints to manage connectors")
 
@@ -114,10 +115,15 @@ class EditInstance(Resource):
     })
     def post(self, cid, iid):
         if ConnectorModel.get_connector(cid):
+            current_user = utils.get_user_from_api(request.headers)
+            if not (ConnectorModel.get_user_instance_both(user_id=current_user.id, instance_id=iid) or current_user.is_admin()):
+                flowintel_log("audit", 403, "API: Edit connector instance denied: not owner", User=current_user.email, ConnectorId=cid, InstanceId=iid)
+                return {"message": "Permission denied"}, 403
             if request.json:
                 verif_dict = ConnectorModelApi.verif_edit_instance(request.json, iid)
                 if not "message" in verif_dict:
                     ConnectorModel.edit_connector_instance_core(iid, verif_dict)
+                    flowintel_log("audit", 200, "API: Connector instance edited", User=current_user.email, ConnectorId=cid, InstanceId=iid)
                     return {"message": "Instance edited", "connector_id": int(iid)}, 200
                 return verif_dict, 400
             return {"message": "Please give data"}, 400
@@ -149,9 +155,14 @@ class DeleteInstanceConnector(Resource):
     def get(self, cid, iid):
         if ConnectorModel.get_connector(cid):
             if ConnectorModel.get_instance(iid):
+                current_user = utils.get_user_from_api(request.headers)
+                if not (ConnectorModel.get_user_instance_both(user_id=current_user.id, instance_id=iid) or current_user.is_admin()):
+                    flowintel_log("audit", 403, "API: Delete connector instance denied: not owner", User=current_user.email, ConnectorId=cid, InstanceId=iid)
+                    return {"message": "Permission denied"}, 403
                 if ConnectorModel.instance_has_links(iid):
                     return {"message":"Instance is linked to a case or task"}, 400
                 if ConnectorModel.delete_connector_instance_core(iid):
+                    flowintel_log("audit", 200, "API: Connector instance deleted", User=current_user.email, ConnectorId=cid, InstanceId=iid)
                     return {"message":"Instance deleted"}, 200
                 return {"message":"Error connector deleted"}, 400
             return {"message":"Instance not found"}, 404

--- a/app/notification/notification.py
+++ b/app/notification/notification.py
@@ -50,6 +50,9 @@ def read_notification(nid):
     """Read Notification"""
     notif = NotifModel.get_notif(nid)
     if notif:
+        if notif.user_id != current_user.id:
+            flowintel_log("audit", 403, "Read notification denied: not owner", User=current_user.email, NotifId=nid)
+            return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
         if NotifModel.read_notification_core(nid):
             return {"message": "Notification read", "toast_class": "success-subtle"}, 200
         return {"message": "Error Notification read", "toast_class": "danger-subtle"}, 400
@@ -61,6 +64,9 @@ def delete_notification(nid):
     """Delete Notification"""
     notif = NotifModel.get_notif(nid)
     if notif:
+        if notif.user_id != current_user.id:
+            flowintel_log("audit", 403, "Delete notification denied: not owner", User=current_user.email, NotifId=nid)
+            return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
         if NotifModel.delete_notification_core(nid):
             return {"message": "Notification deleted", "toast_class": "success-subtle"}, 200
         return {"message": "Error Notification deleted", "toast_class": "danger-subtle"}, 400
@@ -80,10 +86,18 @@ def mark_all_read():
 @login_required
 def mark_password_reset_notifs_as_read(uid):
     """Mark all password reset notifications for a user as read"""
+    if not (current_user.is_admin() or current_user.is_org_admin()):
+        flowintel_log("audit", 403, "Mark password reset notifications as read denied: not admin", User=current_user.email, TargetUserId=uid)
+        return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
+
     user = User.query.get(uid)
     if not user:
         return {"message": "User not found", "toast_class": "danger-subtle"}, 404
-    
+
+    if current_user.is_pure_org_admin() and user.org_id != current_user.org_id:
+        flowintel_log("audit", 403, "Mark password reset notifications as read denied: cross-org", User=current_user.email, TargetUserId=uid)
+        return {"message": "Permission denied", "toast_class": "danger-subtle"}, 403
+
     if NotifModel.mark_password_reset_notifications_as_read(uid):
         flowintel_log("audit", 200, "Password reset notifications marked as read", User=user.email, UserId=uid, By=current_user.email)
         return {"message": "Password reset notifications marked as read for all admins", "toast_class": "success-subtle"}, 200


### PR DESCRIPTION
- AI-generated case report: adjust for private cases
- correlation list: adjust for private cases
- Case history and audit log downloads: adjust for private cases
- Notifications: logged-in user could read or delete notifications belonging to others by guessing the notification id.
- Connector instances: any MISP Editor could edit or delete a connector instance created by another user