### PR TITLE
fix/bug_fixing 

### DIFF
--- a/app/admin/admin_api.py
+++ b/app/admin/admin_api.py
@@ -28,7 +28,8 @@ edit_user_model = admin_ns.model('EditUser', {
     'last_name': fields.String(required=False, description='Last name for the user'),
     'email': fields.String(required=False, description='Email for the user'),
     'role': fields.Integer(required=False, description='Role ID (integer) for the user'),
-    'org': fields.Integer(required=False, description='Organisation ID (integer) for the user')
+    'org': fields.Integer(required=False, description='Organisation ID (integer) for the user'),
+    'password': fields.String(required=False, description='New password for the user (local auth only). Resets the user password.')
 })
 
 add_org_model = admin_ns.model('AddOrg', {
@@ -107,8 +108,8 @@ class GetUserMatrix(Resource):
             user = AdminModel.get_user_by_matrix_id(request.args.get("matrix_id"))
             if user:
                 return user.to_json(), 200
-            return {"message": "No user found for this matrix id"}
-        return {"message": "Need to pass a last name"}, 400
+            return {"message": "No user found for this matrix id"}, 404
+        return {"message": "Need to pass a matrix id"}, 400
 
 @admin_ns.route('/add_user')
 @admin_ns.doc(description='Add new user')

--- a/app/admin/admin_core_api.py
+++ b/app/admin/admin_core_api.py
@@ -1,4 +1,5 @@
 from ..db_class.db import User, Role, Org
+from ..utils.utils import validate_password_strength
 
 
 def verif_add_user(data_dict, api_user=None):
@@ -59,7 +60,15 @@ def verif_edit_user(data_dict, user_id, api_user=None):
     user = User.query.get(user_id)
     if not user:
         return {"message": "User not found"}
-    
+
+    if "password" in data_dict:
+        if not data_dict["password"]:
+            data_dict.pop("password")
+        else:
+            error = validate_password_strength(data_dict["password"])
+            if error:
+                return {"message": error}
+
     if "first_name" not in data_dict or not data_dict["first_name"]:
         data_dict["first_name"] = user.first_name
 

--- a/app/admin/form.py
+++ b/app/admin/form.py
@@ -12,7 +12,7 @@ from wtforms.fields import (
 )
 from wtforms.validators import Email, EqualTo, InputRequired, Length, Optional, Regexp
 from ..db_class.db import User, Org
-from ..utils.utils import isUUID
+from ..utils.utils import isUUID, MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH, validate_password_strength
 
 
 class RegistrationForm(FlaskForm):
@@ -23,7 +23,7 @@ class RegistrationForm(FlaskForm):
     password = PasswordField('Password', validators=[
             InputRequired(),
             EqualTo('password2', 'Passwords must match'),
-            Length(min=8, max=64, message="Password must be between 8 and 64 characters."),
+            Length(min=MIN_PASSWORD_LENGTH, max=MAX_PASSWORD_LENGTH, message=f"Password must be between {MIN_PASSWORD_LENGTH} and {MAX_PASSWORD_LENGTH} characters."),
             Regexp(r'.*[A-Z].*', message="Password must contain at least one uppercase letter."),
             Regexp(r'.*[a-z].*', message="Password must contain at least one lowercase letter."),
             Regexp(r'.*\d.*', message="Password must contain at least one digit.")
@@ -67,14 +67,9 @@ class AdminEditUserFrom(FlaskForm):
         if self.change_password.data:
             if not field.data:
                 raise ValidationError('Password is required when changing password.')
-            if len(field.data) < 8 or len(field.data) > 64:
-                raise ValidationError('Password must be between 8 and 64 characters.')
-            if not any(c.isupper() for c in field.data):
-                raise ValidationError('Password must contain at least one uppercase letter.')
-            if not any(c.islower() for c in field.data):
-                raise ValidationError('Password must contain at least one lowercase letter.')
-            if not any(c.isdigit() for c in field.data):
-                raise ValidationError('Password must contain at least one digit.')
+            error = validate_password_strength(field.data)
+            if error:
+                raise ValidationError(error)
     
     def validate_password2(self, field):
         """Validate password confirmation only if change_password is checked"""

--- a/app/case/TaskCore.py
+++ b/app/case/TaskCore.py
@@ -12,7 +12,6 @@ from ..db_class.db import (
 from ..utils.utils import create_specific_dir, isUUID
 
 from sqlalchemy import and_
-from sqlalchemy.exc import SQLAlchemyError
 from flask import request, send_file
 from werkzeug.utils import secure_filename
 from ..notification import notification_core as NotifModel
@@ -1088,8 +1087,9 @@ class TaskCore(CommonAbstract, FilteringAbstract):
 
         for connector in request_json["connectors"]:
             instance = CommonModel.get_instance_by_name(connector["name"])
-            if "identifier" in connector: loc_identfier = connector["identifier"]
-            else: loc_identfier = ""
+            if not instance:
+                return False
+            loc_identfier = connector.get("identifier", "")
             c = Task_Connector_Instance(
                 task_id=tid,
                 instance_id=instance.id,
@@ -1102,11 +1102,11 @@ class TaskCore(CommonAbstract, FilteringAbstract):
         return True
 
     def remove_connector(self, task_instance_id):
-        try:
-            Task_Connector_Instance.query.filter_by(id=task_instance_id).delete()
-            db.session.commit()
-        except SQLAlchemyError:
+        c = Task_Connector_Instance.query.filter_by(id=task_instance_id).first()
+        if not c:
             return False
+        db.session.delete(c)
+        db.session.commit()
         return True
 
     def edit_connector(self, task_instance_id, request_json):

--- a/app/case/case.py
+++ b/app/case/case.py
@@ -1074,6 +1074,9 @@ def download_file(cid):
         if not check_user_private_case(case):
             flowintel_log("audit", 403, "Download case history: Private case: Permission denied", User=current_user.email, CaseId=cid)
             return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        if not (current_user.is_admin() or current_user.is_case_admin() or current_user.is_audit_viewer()):
+            flowintel_log("audit", 403, "Download case history: Access restricted", User=current_user.email, CaseId=cid)
+            return {"message": "Access restricted", "toast_class": "warning-subtle"}, 403
         flowintel_log("audit", 200, "Download case history", User=current_user.email, CaseId=cid)
         return CaseModel.download_history(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
@@ -1088,6 +1091,9 @@ def download_history_md(cid):
         if not check_user_private_case(case):
             flowintel_log("audit", 403, "Download case markdown: Private case: Permission denied", User=current_user.email, CaseId=cid)
             return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        if not (current_user.is_admin() or current_user.is_case_admin() or current_user.is_audit_viewer()):
+            flowintel_log("audit", 403, "Download case markdown: Access restricted", User=current_user.email, CaseId=cid)
+            return {"message": "Access restricted", "toast_class": "warning-subtle"}, 403
         flowintel_log("audit", 200, "Download case markdown", User=current_user.email, CaseId=cid)
         return CaseModel.download_history_md(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
@@ -1102,6 +1108,9 @@ def download_audit_logs(cid):
         if not check_user_private_case(case):
             flowintel_log("audit", 403, "Download audit logs: Private case: Permission denied", User=current_user.email, CaseId=cid)
             return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        if not (current_user.is_admin() or current_user.is_case_admin() or current_user.is_audit_viewer()):
+            flowintel_log("audit", 403, "Download audit logs: Access restricted", User=current_user.email, CaseId=cid)
+            return {"message": "Access restricted", "toast_class": "warning-subtle"}, 403
         flowintel_log("audit", 200, "Download audit logs", User=current_user.email, CaseId=cid)
         return CommonModel.download_audit_logs(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404
@@ -1116,6 +1125,9 @@ def download_audit_logs_md(cid):
         if not check_user_private_case(case):
             flowintel_log("audit", 403, "Download audit logs markdown: Private case: Permission denied", User=current_user.email, CaseId=cid)
             return {"message": "Permission denied", "toast_class": "warning-subtle"}, 403
+        if not (current_user.is_admin() or current_user.is_case_admin() or current_user.is_audit_viewer()):
+            flowintel_log("audit", 403, "Download audit logs markdown: Access restricted", User=current_user.email, CaseId=cid)
+            return {"message": "Access restricted", "toast_class": "warning-subtle"}, 403
         flowintel_log("audit", 200, "Download audit logs markdown", User=current_user.email, CaseId=cid)
         return CommonModel.download_audit_logs_md(case)
     return {"message": "Case not found", "toast_class": "danger-subtle"}, 404

--- a/app/case/case_api.py
+++ b/app/case/case_api.py
@@ -375,13 +375,56 @@ class History(Resource):
     def get(self, cid):
         case = CommonModel.get_case(cid)
         if case:
-            if not check_user_private_case(case, request.headers):
+            current_user = utils.get_user_from_api(request.headers)
+            if not check_user_private_case(case, request.headers, current_user):
                 return {"message": "Permission denied"}, 403
+            if not (current_user.is_admin() or current_user.is_case_admin() or current_user.is_audit_viewer()):
+                return {"message": "Access restricted"}, 403
             history = CommonModel.get_history(case.uuid)
             if history:
                 return {"history": history}, 200
             return {"history": None}, 200
-        return {"message": "Case Not found"}, 404
+        return {"message": "Case not found"}, 404
+
+
+@case_ns.route('/<cid>/add_link', methods=['POST'])
+@case_ns.doc(description='Link one or more cases to this case', params={'cid': 'id of a case'})
+class AddCaseLink(Resource):
+    method_decorators = [editor_required, api_required]
+    @case_ns.doc(params={"case_id": "Required. List of case ids to link to this case"})
+    def post(self, cid):
+        case = CommonModel.get_case(cid)
+        if not case:
+            return {"message": "Case not found"}, 404
+        current_user = utils.get_user_from_api(request.headers)
+        if not (CommonModel.get_present_in_case(cid, current_user) or current_user.is_admin()):
+            flowintel_log("audit", 403, "Add case link: Permission denied", User=current_user.email, CaseId=cid)
+            return {"message": "Permission denied"}, 403
+        if not request.json or "case_id" not in request.json:
+            return {"message": "Need to pass 'case_id'"}, 400
+        if CaseModel.add_new_link(request.json, cid, current_user):
+            flowintel_log("audit", 200, "Case link added", User=current_user.email, CaseId=cid, LinkedCaseId=request.json["case_id"])
+            return {"message": "Link added"}, 200
+        return {"message": "Case doesn't exist"}, 404
+
+
+@case_ns.route('/<cid>/remove_link/<clid>', methods=['GET'])
+@case_ns.doc(description='Remove a case link', params={'cid': 'id of a case', 'clid': 'id of the linked case'})
+class RemoveCaseLink(Resource):
+    method_decorators = [editor_required, api_required]
+    def get(self, cid, clid):
+        case = CommonModel.get_case(cid)
+        if not case:
+            return {"message": "Case not found"}, 404
+        current_user = utils.get_user_from_api(request.headers)
+        if not (CommonModel.get_present_in_case(cid, current_user) or current_user.is_admin()):
+            flowintel_log("audit", 403, "Remove case link: Action not allowed", User=current_user.email, CaseId=cid, LinkId=clid)
+            return {"message": "Permission denied"}, 403
+        if CaseModel.remove_case_link(cid, clid, current_user):
+            flowintel_log("audit", 200, "Case link removed", User=current_user.email, CaseId=cid, LinkId=clid)
+            return {"message": "Link removed"}, 200
+        return {"message": "Error removing link from case"}, 400
+
 
 @case_ns.route('/<cid>/create_template', methods=["POST"])
 @case_ns.doc(description='Create a template form case', params={'cid': 'id of a case'})
@@ -537,7 +580,7 @@ class GetTaxonomiesCase(Resource):
             if tags:
                 taxonomies = [tag.split(":")[0] for tag in tags]
             return {"tags": tags, "taxonomies": taxonomies}, 200
-        return {"message": "Case Not found"}, 404
+        return {"message": "Case not found"}, 404
 
 @case_ns.route('/get_galaxies', methods=['GET'])
 @case_ns.doc(description='Get all galaxies')
@@ -566,7 +609,7 @@ class GetGalaxiesCase(Resource):
                     index = clusters.index(cluster)
                     clusters[index] = cluster.tag
             return {"clusters": clusters, "galaxies": galaxies}, 200
-        return {"message": "Case Not found"}, 404
+        return {"message": "Case not found"}, 404
     
 
 
@@ -595,7 +638,7 @@ class GetInstanceModules(Resource):
             module = request.args.get("module")
             type_module = request.args.get("type")
             return {"instances": CaseModel.get_instance_module_core(module, type_module, case.id, current_user.id)}, 200
-        return {"message": "Case Not found"}, 404
+        return {"message": "Case not found"}, 404
     
 
 @case_ns.route('/<cid>/call_module_case', methods=['POST'])
@@ -701,7 +744,7 @@ class GetConnectorsCase(Resource):
                     "identifier": case_instance.identifier
                 })
             return {"connectors": instance_list}, 200
-        return {"message": "Case Not found"}, 404
+        return {"message": "Case not found"}, 404
     
 @case_ns.route('/<cid>/add_connectors', methods=['POST'])
 @case_ns.doc(description='Add connectors to a case')
@@ -930,9 +973,9 @@ class ChangeOrder(Resource):
                             return {"message": "Order changed"}, 200
                         return {"message": "New index is not one of an other task"}, 400
                     return {"message": "'new-index' need to be passed"}, 400
-                return {"message": "Task Not found"}, 404
+                return {"message": "Task not found"}, 404
             return {"message": "Permission denied"}, 403
-        return {"message": "Case Not found"}, 404
+        return {"message": "Case not found"}, 404
     
 
 @case_ns.route('/<cid>/all_notes')

--- a/app/case/task_api.py
+++ b/app/case/task_api.py
@@ -543,7 +543,7 @@ class AddConnectorsTask(Resource):
                     return {"message": "Task in restricted status can only be modified by Admin, Case Admin or Queue Admin"}, 403
                 
                 if "connectors" in request.json:
-                    if TaskModel.add_connector(tid, request.json):
+                    if TaskModel.add_connector(tid, request.json, current_user):
                         return {"message": "Connector added"}, 200
                     return {"message": "Error Connector added"}, 400
                 return {"message": "Please give a list of connectors"}, 400
@@ -801,3 +801,76 @@ class DeleteUrlTool(Resource):
             return {"message": "Permission denied"}, 403
         return {"message": "Task Not found"}, 404
     
+
+######################
+# External reference #
+######################
+
+@task_ns.route('/<tid>/create_external_reference', methods=['POST'])
+@task_ns.doc(description='Create an external reference for a task')
+class CreateExternalReferenceTask(Resource):
+    method_decorators = [editor_required, api_required]
+    @task_ns.doc(params={"url": "Required. URL of the external reference"})
+    def post(self, tid):
+        task = CommonModel.get_task(tid)
+        if not task:
+            return {"message": "Task not found"}, 404
+        current_user = utils.get_user_from_api(request.headers)
+        if not (CommonModel.get_present_in_case(task.case_id, current_user) or current_user.is_admin()):
+            return {"message": "Permission denied"}, 403
+        if TaskModel.is_task_restricted(task) and not TaskModel.can_edit_requested_task(current_user):
+            flowintel_log("audit", 403, "Create external reference denied: Task in Requested or Rejected status", User=current_user.email, CaseId=task.case_id, TaskId=tid)
+            return {"message": "Task in Requested or Rejected status can only be modified by Admin, Case Admin or Queue Admin"}, 403
+        if not request.json or "url" not in request.json:
+            return {"message": "Need to pass 'url'"}, 400
+        external_ref = TaskModel.create_external_reference(tid, request.json["url"], current_user)
+        if external_ref:
+            flowintel_log("audit", 201, "External reference created for task", User=current_user.email, CaseId=task.case_id, TaskId=tid, ExternalRefId=external_ref.id, URL=external_ref.url)
+            return {"message": "External reference created", "external_ref_id": external_ref.id}, 201
+        return {"message": "Error creating external reference"}, 400
+
+
+@task_ns.route('/<tid>/edit_external_reference/<erid>', methods=['POST'])
+@task_ns.doc(description='Edit an external reference of a task')
+class EditExternalReferenceTask(Resource):
+    method_decorators = [editor_required, api_required]
+    @task_ns.doc(params={"url": "Required. URL of the external reference"})
+    def post(self, tid, erid):
+        task = CommonModel.get_task(tid)
+        if not task:
+            return {"message": "Task not found"}, 404
+        current_user = utils.get_user_from_api(request.headers)
+        if not (CommonModel.get_present_in_case(task.case_id, current_user) or current_user.is_admin()):
+            return {"message": "Permission denied"}, 403
+        if TaskModel.is_task_restricted(task) and not TaskModel.can_edit_requested_task(current_user):
+            flowintel_log("audit", 403, "Edit external reference denied: Task in Requested or Rejected status", User=current_user.email, CaseId=task.case_id, TaskId=tid, ExternalRefId=erid)
+            return {"message": "Task in Requested or Rejected status can only be modified by Admin, Case Admin or Queue Admin"}, 403
+        if not request.json or "url" not in request.json:
+            return {"message": "Need to pass 'url'"}, 400
+        if TaskModel.edit_external_reference(tid, erid, request.json["url"], current_user):
+            flowintel_log("audit", 200, "External reference edited for task", User=current_user.email, CaseId=task.case_id, TaskId=tid, ExternalRefId=erid, URL=request.json["url"])
+            return {"message": "External reference edited"}, 200
+        return {"message": "External reference not found"}, 404
+
+
+@task_ns.route('/<tid>/delete_external_reference/<erid>', methods=['GET'])
+@task_ns.doc(description='Delete an external reference of a task')
+class DeleteExternalReferenceTask(Resource):
+    method_decorators = [editor_required, api_required]
+    def get(self, tid, erid):
+        task = CommonModel.get_task(tid)
+        if not task:
+            return {"message": "Task not found"}, 404
+        current_user = utils.get_user_from_api(request.headers)
+        if not (CommonModel.get_present_in_case(task.case_id, current_user) or current_user.is_admin()):
+            return {"message": "Permission denied"}, 403
+        if TaskModel.is_task_restricted(task) and not TaskModel.can_edit_requested_task(current_user):
+            flowintel_log("audit", 403, "Delete external reference denied: Task in Requested or Rejected status", User=current_user.email, CaseId=task.case_id, TaskId=tid, ExternalRefId=erid)
+            return {"message": "Task in Requested or Rejected status can only be modified by Admin, Case Admin or Queue Admin"}, 403
+        external_ref = TaskModel.get_external_reference(erid)
+        if not external_ref or external_ref.task_id != int(tid):
+            return {"message": "External reference not found"}, 404
+        url = external_ref.url
+        TaskModel.delete_external_reference(external_ref, current_user)
+        flowintel_log("audit", 200, "External reference deleted from task", User=current_user.email, CaseId=task.case_id, TaskId=tid, ExternalRefId=erid, URL=url)
+        return {"message": "External reference deleted"}, 200

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -16,6 +16,26 @@ from flask import current_app
 from conf.config import Config
 from pymisp.tools import update_objects
 
+MIN_PASSWORD_LENGTH = 8
+MAX_PASSWORD_LENGTH = 64
+
+
+def validate_password_strength(password):
+    """Return None if `password` meets the policy, otherwise an error message.
+
+    Mirrors the rules defined on `RegistrationForm`/`AdminEditUserFrom` so the
+    REST API and the web forms reject the same inputs with the same wording.
+    """
+    if not (MIN_PASSWORD_LENGTH <= len(password) <= MAX_PASSWORD_LENGTH):
+        return f"Password must be between {MIN_PASSWORD_LENGTH} and {MAX_PASSWORD_LENGTH} characters."
+    if not any(c.isupper() for c in password):
+        return "Password must contain at least one uppercase letter."
+    if not any(c.islower() for c in password):
+        return "Password must contain at least one lowercase letter."
+    if not any(c.isdigit() for c in password):
+        return "Password must contain at least one digit."
+    return None
+
 
 def validate_file_size(file, max_size=None):
     """Validate file size against maximum allowed size."""

--- a/tests/admin/test_org_user_admin.py
+++ b/tests/admin/test_org_user_admin.py
@@ -201,6 +201,68 @@ def test_delete_org(client):
     assert response.status_code == 200
     assert b"Org deleted" in response.data
 
+def test_delete_org_with_users(client):
+    """Admin should NOT be able to delete an organisation that still has users"""
+    org_id = create_test_org(client).json["org_id"]
+    email = f"orguser{int(time.time() * 1000000)}@test.test"
+    add = client.post("/api/admin/add_user",
+                      content_type='application/json',
+                      headers={"X-API-KEY": API_KEY},
+                      json={"first_name": "u", "last_name": "u", "email": email,
+                            "password": "password", "role": 2, "org": org_id})
+    assert add.status_code == 201
+
+    response = client.get(f"/api/admin/delete_org/{org_id}", headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 403
+    assert b"has users" in response.data
+
+def test_delete_org_with_users_and_cases(client):
+    """Admin should NOT be able to delete an organisation that has users and owns cases"""
+    org_id = create_test_org(client).json["org_id"]
+    email = f"orguser{int(time.time() * 1000000)}@test.test"
+    add = client.post("/api/admin/add_user",
+                      content_type='application/json',
+                      headers={"X-API-KEY": API_KEY},
+                      json={"first_name": "u", "last_name": "u", "email": email,
+                            "password": "password", "role": 2, "org": org_id})
+    assert add.status_code == 201
+    new_user_api_key = add.json["api_key"]
+
+    case = client.post("/api/case/create",
+                       content_type='application/json',
+                       headers={"X-API-KEY": new_user_api_key},
+                       json={"title": "Case owned by new org"})
+    assert case.status_code == 201
+
+    response = client.get(f"/api/admin/delete_org/{org_id}", headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 403
+    assert b"has users" in response.data
+    assert b"owns cases" in response.data
+
+def test_edit_user_password_reset(client):
+    """Admin should be able to reset a local user's password via the API"""
+    create_response = create_test_user(client)
+    user_id = create_response.json["id"]
+
+    response = client.post(f"/api/admin/edit_user/{user_id}",
+                           content_type='application/json',
+                           headers={"X-API-KEY": API_KEY},
+                           json={"password": "NewPassword123"})
+    assert response.status_code == 200
+    assert b"User edited" in response.data
+
+def test_edit_user_password_too_short(client):
+    """Admin password reset must enforce the password policy"""
+    create_response = create_test_user(client)
+    user_id = create_response.json["id"]
+
+    response = client.post(f"/api/admin/edit_user/{user_id}",
+                           content_type='application/json',
+                           headers={"X-API-KEY": API_KEY},
+                           json={"password": "short"})
+    assert response.status_code == 400
+    assert b"between 8 and 64 characters" in response.data
+
 def test_get_orgs(client):
     """Admin should be able to list all organisations"""
     response = client.get("/api/admin/orgs", headers={"X-API-KEY": API_KEY})

--- a/tests/admin/test_org_user_editor.py
+++ b/tests/admin/test_org_user_editor.py
@@ -56,11 +56,15 @@ def test_delete_user_forbidden(client):
     response = client.get(f"/api/admin/delete_user/{user_id}", headers={"X-API-KEY": API_KEY})
     assert response.status_code == 403
 
-def test_get_users_forbidden(client):
-    """Editor should NOT be able to list all users (depends on LIMIT_USER_VIEW_TO_ORG config)"""
+def test_get_users(client):
+    """Editor can list users in their own organisation (LIMIT_USER_VIEW_TO_ORG=True in tests)."""
     response = client.get("/api/admin/users", headers={"X-API-KEY": API_KEY})
-    # Return 200 or 403 depending on configuration
-    assert response.status_code in [200, 403]
+    assert response.status_code == 200
+    assert "users" in response.json
+    with client.application.app_context():
+        own = get_user_api(API_KEY)
+        for u in response.json["users"]:
+            assert u["org_id"] == own.org_id
 
 def test_get_specific_user(client):
     """Editor should be able to get their own user details"""

--- a/tests/admin/test_org_user_readonly.py
+++ b/tests/admin/test_org_user_readonly.py
@@ -57,10 +57,14 @@ def test_delete_user_forbidden(client):
     assert response.status_code == 403
 
 def test_get_users(client):
-    """Read-only user should be able to list users (depends on LIMIT_USER_VIEW_TO_ORG config)"""
+    """Read-only user can list users in their own organisation (LIMIT_USER_VIEW_TO_ORG=True in tests)."""
     response = client.get("/api/admin/users", headers={"X-API-KEY": API_KEY})
-    # This might return 200 or 403 depending on configuration
-    assert response.status_code in [200, 403]
+    assert response.status_code == 200
+    assert "users" in response.json
+    with client.application.app_context():
+        own = get_user_api(API_KEY)
+        for u in response.json["users"]:
+            assert u["org_id"] == own.org_id
 
 def test_get_specific_user(client):
     """Read-only user should be able to get their own user details"""
@@ -73,13 +77,13 @@ def test_get_specific_user(client):
     assert response.json["email"] == "read@read.read"
 
 def test_get_other_user(client):
-    """Read-only user should be able to view other users (if permissions allow)"""
+    """Read-only user can fetch a specific user by id (no org check on this endpoint)."""
     create_response = create_user_as_admin(client)
     user_id = create_response.json["id"]
-    
+
     response = client.get(f"/api/admin/user/{user_id}", headers={"X-API-KEY": API_KEY})
-    # Might be allowed or forbidden depending on config
-    assert response.status_code in [200, 403]
+    assert response.status_code == 200
+    assert response.json["id"] == user_id
 
 #########
 ## Org ##

--- a/tests/case/test_case_history_audit_guard.py
+++ b/tests/case/test_case_history_audit_guard.py
@@ -1,0 +1,44 @@
+API_KEY = "editor_api_key"
+ADMIN_KEY = "admin_api_key"
+AUDIT_VIEWER_KEY = "audit_viewer_api_key"
+READ_KEY = "read_api_key"
+
+
+def create_case(client):
+    return client.post("/api/case/create",
+                       content_type="application/json",
+                       headers={"X-API-KEY": API_KEY},
+                       json={"title": "Audit Guard Case"})
+
+
+def test_history_admin_allowed(client):
+    """Admin can read case history via the API"""
+    cid = create_case(client).json["case_id"]
+    response = client.get(f"/api/case/{cid}/history",
+                          headers={"X-API-KEY": ADMIN_KEY})
+    assert response.status_code == 200
+
+
+def test_history_audit_viewer_allowed(client):
+    """AuditViewer can read case history via the API"""
+    cid = create_case(client).json["case_id"]
+    response = client.get(f"/api/case/{cid}/history",
+                          headers={"X-API-KEY": AUDIT_VIEWER_KEY})
+    assert response.status_code == 200
+
+
+def test_history_editor_denied(client):
+    """Plain Editor cannot read case history via the API"""
+    cid = create_case(client).json["case_id"]
+    response = client.get(f"/api/case/{cid}/history",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 403
+    assert response.json["message"] == "Access restricted"
+
+
+def test_history_read_only_denied(client):
+    """Read-only user cannot read case history via the API"""
+    cid = create_case(client).json["case_id"]
+    response = client.get(f"/api/case/{cid}/history",
+                          headers={"X-API-KEY": READ_KEY})
+    assert response.status_code == 403

--- a/tests/case/test_case_links_api.py
+++ b/tests/case/test_case_links_api.py
@@ -1,0 +1,85 @@
+API_KEY = "editor_api_key"
+READ_KEY = "read_api_key"
+
+
+def create_case(client, title="Link Test Case"):
+    return client.post("/api/case/create",
+                       content_type="application/json",
+                       headers={"X-API-KEY": API_KEY},
+                       json={"title": title})
+
+
+def test_add_case_link(client):
+    """Editor can link two cases via the API"""
+    cid_a = create_case(client, "Case A").json["case_id"]
+    cid_b = create_case(client, "Case B").json["case_id"]
+
+    response = client.post(f"/api/case/{cid_a}/add_link",
+                           content_type="application/json",
+                           headers={"X-API-KEY": API_KEY},
+                           json={"case_id": [cid_b]})
+    assert response.status_code == 200
+    assert response.json["message"] == "Link added"
+
+
+def test_add_case_link_missing_payload(client):
+    """add_link without 'case_id' returns 400"""
+    cid = create_case(client).json["case_id"]
+    response = client.post(f"/api/case/{cid}/add_link",
+                           content_type="application/json",
+                           headers={"X-API-KEY": API_KEY},
+                           json={})
+    assert response.status_code == 400
+
+
+def test_add_case_link_unknown_target(client):
+    """Linking to a non-existent case returns 404"""
+    cid = create_case(client).json["case_id"]
+    response = client.post(f"/api/case/{cid}/add_link",
+                           content_type="application/json",
+                           headers={"X-API-KEY": API_KEY},
+                           json={"case_id": [9999]})
+    assert response.status_code == 404
+
+
+def test_add_case_link_read_only_denied(client):
+    """Read-only user cannot link cases"""
+    cid_a = create_case(client, "Case A").json["case_id"]
+    cid_b = create_case(client, "Case B").json["case_id"]
+    response = client.post(f"/api/case/{cid_a}/add_link",
+                           content_type="application/json",
+                           headers={"X-API-KEY": READ_KEY},
+                           json={"case_id": [cid_b]})
+    assert response.status_code == 403
+
+
+def test_remove_case_link(client):
+    """Editor can remove a case link via the API"""
+    cid_a = create_case(client, "Case A").json["case_id"]
+    cid_b = create_case(client, "Case B").json["case_id"]
+    client.post(f"/api/case/{cid_a}/add_link",
+                content_type="application/json",
+                headers={"X-API-KEY": API_KEY},
+                json={"case_id": [cid_b]})
+
+    response = client.get(f"/api/case/{cid_a}/remove_link/{cid_b}",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 200
+    assert response.json["message"] == "Link removed"
+
+
+def test_remove_case_link_unknown(client):
+    """Removing a non-existent link returns 400"""
+    cid = create_case(client).json["case_id"]
+    response = client.get(f"/api/case/{cid}/remove_link/9999",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 400
+
+
+def test_remove_case_link_read_only_denied(client):
+    """Read-only user cannot remove case links"""
+    cid_a = create_case(client, "Case A").json["case_id"]
+    cid_b = create_case(client, "Case B").json["case_id"]
+    response = client.get(f"/api/case/{cid_a}/remove_link/{cid_b}",
+                          headers={"X-API-KEY": READ_KEY})
+    assert response.status_code == 403

--- a/tests/case/test_case_workflow.py
+++ b/tests/case/test_case_workflow.py
@@ -1,4 +1,5 @@
 API_KEY = "editor_api_key"
+ADMIN_KEY = "admin_api_key"
 READ_KEY = "read_api_key"
 
 
@@ -164,11 +165,11 @@ def test_check_title_missing_field(client):
 #############
 
 def test_history(client):
-    """Editor should be able to view case history"""
+    """Admin should be able to view case history (editor needs audit-viewer permission)"""
     case_id = create_case(client).json["case_id"]
 
     response = client.get(f"/api/case/{case_id}/history",
-                          headers={"X-API-KEY": API_KEY})
+                          headers={"X-API-KEY": ADMIN_KEY})
     assert response.status_code == 200
     assert "history" in response.json
 
@@ -176,7 +177,7 @@ def test_history(client):
 def test_history_nonexistent_case(client):
     """Viewing history of a non-existent case should return 404"""
     response = client.get("/api/case/9999/history",
-                          headers={"X-API-KEY": API_KEY})
+                          headers={"X-API-KEY": ADMIN_KEY})
     assert response.status_code == 404
 
 

--- a/tests/case/test_task_api_extras.py
+++ b/tests/case/test_task_api_extras.py
@@ -1,0 +1,222 @@
+API_KEY = "editor_api_key"
+READ_KEY = "read_api_key"
+ADMIN_KEY = "admin_api_key"
+
+
+def create_case(client):
+    return client.post("/api/case/create",
+                       content_type="application/json",
+                       headers={"X-API-KEY": API_KEY},
+                       json={"title": "Task API Test Case"})
+
+
+def create_task(client, case_id):
+    return client.post(f"/api/case/{case_id}/create_task",
+                       content_type="application/json",
+                       headers={"X-API-KEY": API_KEY},
+                       json={"title": "Task API Test Task"})
+
+
+###########################
+## Delete task note (API) ##
+###########################
+
+def create_note(client, task_id, note="hello"):
+    return client.post(f"/api/task/{task_id}/create_note",
+                       content_type="application/json",
+                       headers={"X-API-KEY": API_KEY},
+                       json={"note": note})
+
+
+def list_notes(client, task_id):
+    return client.get(f"/api/task/{task_id}/get_all_notes",
+                      headers={"X-API-KEY": API_KEY})
+
+
+def test_delete_note_api(client):
+    """Editor can delete a task note via the API"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+    create_note(client, task_id)
+
+    notes = list_notes(client, task_id).json["notes"]
+    assert len(notes) == 1
+    note_id = notes[0]["id"]
+
+    response = client.get(f"/api/task/{task_id}/delete_note?note_id={note_id}",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 200
+
+
+def test_delete_note_api_missing_param(client):
+    """delete_note without 'note_id' returns 400"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.get(f"/api/task/{task_id}/delete_note",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 400
+
+
+def test_delete_note_api_read_only_denied(client):
+    """Read-only user cannot delete task notes"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+    create_note(client, task_id)
+    note_id = list_notes(client, task_id).json["notes"][0]["id"]
+
+    response = client.get(f"/api/task/{task_id}/delete_note?note_id={note_id}",
+                          headers={"X-API-KEY": READ_KEY})
+    assert response.status_code == 403
+
+
+###############################
+## External references (API) ##
+###############################
+
+def create_external_ref(client, task_id, url="https://example.com"):
+    return client.post(f"/api/task/{task_id}/create_external_reference",
+                       content_type="application/json",
+                       headers={"X-API-KEY": API_KEY},
+                       json={"url": url})
+
+
+def test_create_external_reference_api(client):
+    """Editor can create an external reference on a task via the API"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = create_external_ref(client, task_id)
+    assert response.status_code == 201
+    assert "external_ref_id" in response.json
+
+
+def test_create_external_reference_api_missing_url(client):
+    """create_external_reference without 'url' returns 400"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.post(f"/api/task/{task_id}/create_external_reference",
+                           content_type="application/json",
+                           headers={"X-API-KEY": API_KEY},
+                           json={})
+    assert response.status_code == 400
+
+
+def test_edit_external_reference_api(client):
+    """Editor can edit an external reference"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+    erid = create_external_ref(client, task_id).json["external_ref_id"]
+
+    response = client.post(f"/api/task/{task_id}/edit_external_reference/{erid}",
+                           content_type="application/json",
+                           headers={"X-API-KEY": API_KEY},
+                           json={"url": "https://edited.example.com"})
+    assert response.status_code == 200
+
+
+def test_edit_external_reference_api_unknown(client):
+    """Editing a missing external reference returns 404"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.post(f"/api/task/{task_id}/edit_external_reference/9999",
+                           content_type="application/json",
+                           headers={"X-API-KEY": API_KEY},
+                           json={"url": "https://x.com"})
+    assert response.status_code == 404
+
+
+def test_delete_external_reference_api(client):
+    """Editor can delete an external reference"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+    erid = create_external_ref(client, task_id).json["external_ref_id"]
+
+    response = client.get(f"/api/task/{task_id}/delete_external_reference/{erid}",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 200
+
+
+def test_delete_external_reference_api_unknown(client):
+    """Deleting a missing external reference returns 404"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.get(f"/api/task/{task_id}/delete_external_reference/9999",
+                          headers={"X-API-KEY": API_KEY})
+    assert response.status_code == 404
+
+
+def test_external_reference_read_only_denied(client):
+    """Read-only user cannot create external references"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.post(f"/api/task/{task_id}/create_external_reference",
+                           content_type="application/json",
+                           headers={"X-API-KEY": READ_KEY},
+                           json={"url": "https://example.com"})
+    assert response.status_code == 403
+
+
+########################
+## Connectors on task ##
+########################
+
+def test_get_connectors_on_task(client):
+    """Editor can list connectors on a task (empty by default)"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.get(f"/api/task/{task_id}/get_connectors",
+                          headers={"X-API-KEY": ADMIN_KEY})
+    assert response.status_code == 200
+    assert response.json["connectors"] == []
+
+
+def test_add_connectors_missing_payload(client):
+    """add_connectors without 'connectors' returns 400"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.post(f"/api/task/{task_id}/add_connectors",
+                           content_type="application/json",
+                           headers={"X-API-KEY": ADMIN_KEY},
+                           json={})
+    assert response.status_code == 400
+
+
+def test_add_connectors_unknown_instance(client):
+    """add_connectors with an unknown instance returns 400"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.post(f"/api/task/{task_id}/add_connectors",
+                           content_type="application/json",
+                           headers={"X-API-KEY": ADMIN_KEY},
+                           json={"connectors": [{"name": "no-such-instance", "identifier": ""}]})
+    assert response.status_code == 400
+
+
+def test_remove_connector_unknown(client):
+    """remove_connector on unknown instance returns 400"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.get(f"/api/task/{task_id}/remove_connector/9999",
+                          headers={"X-API-KEY": ADMIN_KEY})
+    assert response.status_code == 400
+
+
+def test_edit_connector_missing_payload(client):
+    """edit_connector without 'identifier' returns 400"""
+    case_id = create_case(client).json["case_id"]
+    task_id = create_task(client, case_id).json["task_id"]
+
+    response = client.post(f"/api/task/{task_id}/edit_connector/9999",
+                           content_type="application/json",
+                           headers={"X-API-KEY": ADMIN_KEY},
+                           json={})
+    assert response.status_code == 400


### PR DESCRIPTION
Bug fixes and minor improvements after going through the test plan

- Minor textual changes in admin_api
- Allow password change via API request
- Start using constants for min and max password length
- Restrict case history to admin, case-admin, or audit-viewer role, on both the web UI and API
- API calls to add_link / remove_link cases
- API calls to add / remove external references on tasks
- Add additional tests for edit password via API and delete org that still has users/cases
- Proper return code (200) for users / orgs
- Test cases for history / audit
- Test cases to link cases via API
- Additional test cases for tasks