### PR TITLE
fix/avoid_changing_python_env_for_existing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 # https://github.com/flowintel/flowintel
 
+# Install variables
+VENV_DIR="env"
+
 if apt -v &> /dev/null ; then
     sudo apt install -y python3-venv git screen libolm-dev librsvg2-bin wget valkey
     # install pandoc from git 
@@ -75,8 +78,8 @@ else
     PYTHON_CMD=python3
 fi
 
-$PYTHON_CMD -m venv .venv
-. .venv/bin/activate
+$PYTHON_CMD -m venv "$VENV_DIR"
+. "$VENV_DIR/bin/activate"
 pip install --upgrade uv
 uv pip install -r requirements.txt
 

--- a/launch.sh
+++ b/launch.sh
@@ -7,7 +7,7 @@ isscripted_misp_mod=`screen -ls | egrep '[0-9]+.misp_mod_flowintel' | cut -d. -f
 history_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Directory of the python virtualenv to use; can be overridden by env var
-VENV_DIR="${VENV_DIR:-.venv}"
+VENV_DIR="${VENV_DIR:-env}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
- Avoid changing the Python environment for existing installations
- Use variable to define the Python environment path
- Safe installer (with state check - install.safe.sh) was unaffected