### PR TITLE
fix/alert_hooking_remove_printf 

### DIFF
--- a/app/case/CaseCore.py
+++ b/app/case/CaseCore.py
@@ -131,30 +131,35 @@ class CaseCore(CommonAbstract, FilteringAbstract):
         CommonModel.save_history(case.uuid, user, "Case Created")
 
         # Trigger webhook and create alert for new cases
+        webhook_status = None
         try:
-            webhook_status = None
-            from app.utils.utils import get_modules_list
-            modules, _ = get_modules_list()
-            case_json = case.to_json()
-            case_json["status"] = CommonModel.get_status(case.status_id).name
-            case_json["org_name"] = user.Org.name if user.Org else ""
-            dummy_task = {"id": 0, "title": "", "case_id": case.id}
-            if "webhook" in modules and ConfigModule.WEBHOOK_ENABLED:
-                webhook_status = modules["webhook"].handler(dummy_task, case_json, user, user)
+            if getattr(ConfigModule, "WEBHOOK_ENABLED", False):
+                from app.utils.utils import get_modules_list
+                modules, _ = get_modules_list()
+                if "webhook" in modules:
+                    case_json = case.to_json()
+                    case_json["status"] = CommonModel.get_status(case.status_id).name
+                    case_json["org_name"] = user.Org.name if user.Org else ""
+                    dummy_task = {"id": 0, "title": "", "case_id": case.id}
+                    webhook_status = modules["webhook"].handler(dummy_task, case_json, user, user)
+        except Exception:
+            current_app.logger.exception("Webhook delivery failed for case %s", case.id)
 
+        try:
             from app.db_class.db import Alert
             status = "sent" if webhook_status and webhook_status < 300 else "error" if webhook_status is None else "pending"
             alert = Alert(
                 case_id=case.id,
                 message=f"New case created: {case.title}",
                 status=status,
-                webhook_url=ConfigModule.WEBHOOK_URL if hasattr(ConfigModule, 'WEBHOOK_URL') else "",
+                webhook_url=getattr(ConfigModule, "WEBHOOK_URL", ""),
                 webhook_status=webhook_status,
             )
             db.session.add(alert)
             db.session.commit()
-        except Exception as e:
-            print(f"Alert/Webhook error: {e}")
+        except Exception:
+            db.session.rollback()
+            current_app.logger.exception("Failed to create Alert for case %s", case.id)
 
         return case
 


### PR DESCRIPTION
- Avoid failing silently if config_module.py does not contain required settings
- Use logging instead of print statements for better debugging and error handling