### PR TITLE
Mitigate SSRF in external reference URL probing

### DIFF
--- a/app/case/task.py
+++ b/app/case/task.py
@@ -1,11 +1,14 @@
 import ast
+import ipaddress
 import os
+import socket
 import uuid
 
 import requests
 
 from datetime import datetime
 from flask import Blueprint, render_template, redirect, jsonify, request, flash, current_app
+from urllib.parse import urlparse
 
 from app.db_class.db import Case, User, db, Note
 
@@ -932,6 +935,35 @@ def delete_external_reference(cid, tid, erid):
 
 def _probe_external_url(url):
     """Probe a URL to detect common connection failures before invoking misp-modules."""
+    try:
+        parsed_url = urlparse(url)
+    except ValueError:
+        return "The URL is not valid"
+
+    if parsed_url.scheme not in ["http", "https"]:
+        return "Only http:// and https:// URLs are allowed"
+
+    if not parsed_url.hostname:
+        return "The URL is missing a hostname"
+
+    try:
+        addrinfo = socket.getaddrinfo(parsed_url.hostname, None)
+    except socket.gaierror:
+        return "The host likely doesn't exist (DNS resolution failed)"
+
+    for result in addrinfo:
+        ip = result[4][0]
+        parsed_ip = ipaddress.ip_address(ip)
+        if (
+            parsed_ip.is_private
+            or parsed_ip.is_loopback
+            or parsed_ip.is_link_local
+            or parsed_ip.is_multicast
+            or parsed_ip.is_reserved
+            or parsed_ip.is_unspecified
+        ):
+            return "The URL resolves to a restricted network address"
+
     try:
         requests.head(url, timeout=10, allow_redirects=True)
     except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
### Motivation
- Close an exploitable SSRF vector in the external-reference conversion flow where `_probe_external_url()` called `requests.head()` on user-supplied URLs, allowing internal/metadata endpoints (e.g. `169.254.169.254`) to be contacted.

### Description
- Add imports for `urlparse`, `socket`, and `ipaddress` and perform strict URL parsing in `_probe_external_url()` using `urlparse` before making any network request.
- Only allow `http` and `https` schemes and require a hostname to be present in the parsed URL.
- Perform DNS resolution with `socket.getaddrinfo()` and inspect every resolved address with `ipaddress.ip_address()` to reject private, loopback, link-local, multicast, reserved, or unspecified addresses.
- Preserve the existing `requests.head(...)` preflight call and existing exception-to-user-message mappings for connection, timeout, and URL errors after the new pre-checks.

### Testing
- Ran `python -m py_compile app/case/task.py` and it succeeded with no syntax errors.
- Verified the change was committed and only `app/case/task.py` was modified as intended.
- No new unit tests were added in this PR (behaviour validated via static compile and code inspection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e52ab5088324bfd829313cd9d42d)