### PR TITLE
improvement/check_current_sessions 

### DIFF
--- a/app/admin/admin_core.py
+++ b/app/admin/admin_core.py
@@ -244,20 +244,83 @@ def admin_edit_user_core(form_dict, id):
         delete_default_org(prev_user_org_id)
 
 
-def _invalidate_user_sessions(user_id):
-    """Remove all server-side sessions belonging to a user."""
+def _iter_user_sessions():
+    """Yield (key, data) for every stored server-side session."""
     redis_client = current_app.config.get("SESSION_REDIS")
     if not redis_client:
         return
     prefix = current_app.config.get("SESSION_KEY_PREFIX", "session:")
     decoder = msgspec.msgpack.Decoder()
     for key in redis_client.scan_iter(f"{prefix}*"):
+        raw = redis_client.get(key)
+        if raw is None:
+            continue
         try:
-            data = decoder.decode(redis_client.get(key))
-            if data.get("_user_id") == str(user_id):
-                redis_client.delete(key)
+            yield key, decoder.decode(raw)
         except Exception:
             continue
+
+
+def _invalidate_user_sessions(user_id):
+    """Remove all server-side sessions belonging to a user."""
+    redis_client = current_app.config.get("SESSION_REDIS")
+    if not redis_client:
+        return
+    for key, data in _iter_user_sessions():
+        if data.get("_user_id") == str(user_id):
+            redis_client.delete(key)
+
+
+# Idle time is (lifetime - ttl), since the TTL resets on each request.
+ACTIVE_SESSION_THRESHOLD_MINUTES = 15
+
+
+def list_active_user_sessions(exclude_user_id=None):
+    """Return distinct users active within the threshold, optionally excluding one."""
+    redis_client = current_app.config.get("SESSION_REDIS")
+    if not redis_client:
+        return []
+
+    lifetime = current_app.config.get("PERMANENT_SESSION_LIFETIME") or datetime.timedelta(days=31)
+    lifetime_seconds = lifetime.total_seconds()
+    threshold_seconds = ACTIVE_SESSION_THRESHOLD_MINUTES * 60
+
+    # user_id -> {"count": sessions, "idle": idle of the most recent one}
+    active = {}
+    for key, data in _iter_user_sessions():
+        user_id = data.get("_user_id")
+        if not user_id or user_id == str(exclude_user_id):
+            continue
+
+        ttl = redis_client.ttl(key)
+        if ttl == -2:  # key expired between scan and read
+            continue
+        # ttl == -1 means no expiry, which we treat as just-active
+        idle = 0 if ttl < 0 else max(0, lifetime_seconds - ttl)
+        if idle > threshold_seconds:
+            continue
+
+        if user_id in active:
+            active[user_id]["count"] += 1
+            active[user_id]["idle"] = min(active[user_id]["idle"], idle)
+        else:
+            active[user_id] = {"count": 1, "idle": idle}
+
+    sessions = []
+    for user_id, entry in active.items():
+        user = get_user(user_id)
+        if not user:
+            continue
+        name = f"{user.first_name or ''} {user.last_name or ''}".strip() or user.email
+        sessions.append({
+            "id": user.id,
+            "name": name,
+            "email": user.email,
+            "sessions": entry["count"],
+            "idle_seconds": int(entry["idle"]),
+        })
+    sessions.sort(key=lambda u: u["idle_seconds"])
+    return sessions
 
 
 def delete_user_core(id):

--- a/app/templates/tools/system_settings.html
+++ b/app/templates/tools/system_settings.html
@@ -130,9 +130,9 @@
                     <hr class="my-2">
                     <div class="d-flex align-items-center justify-content-between">
                         <small class="text-muted">Reload the application to apply <code>config.py</code> changes</small>
-                        <button class="btn btn-sm btn-outline-warning" @click="confirmReload" :disabled="reloading">
+                        <button class="btn btn-sm btn-outline-warning" @click="openReloadDialog" :disabled="reloading || checkingSessions">
                             <i class="fa-solid fa-arrows-rotate me-1" :class="{ 'fa-spin': reloading }"></i>
-                            [[ reloading ? 'Reloading…' : 'Reload application' ]]
+                            [[ reloading ? 'Reloading…' : (checkingSessions ? 'Checking…' : 'Reload application') ]]
                         </button>
                     </div>
                 </div>
@@ -679,6 +679,59 @@
     </div>
 </div>
 
+<!-- ── Reload confirmation modal ── -->
+<div v-if="showReloadModal" class="modal fade show" style="display: block;" tabindex="-1" @click.self="closeReloadDialog">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="fa-solid fa-arrows-rotate me-2"></i>Reload application</h5>
+                <button type="button" class="btn-close" @click="closeReloadDialog" :disabled="reloading"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-2">
+                    This will gracefully restart all application workers to pick up
+                    <code>config.py</code> changes. Active requests will finish before reloading.
+                </p>
+                <div v-if="sessionsError" class="alert alert-secondary mb-2">
+                    <i class="fa-solid fa-circle-question me-1"></i>
+                    Could not check for connected users. Reload only if you are sure no one else is using the application.
+                </div>
+                <div v-else-if="connectedUsers.length" class="alert alert-warning mb-2">
+                    <div class="fw-bold mb-1">
+                        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+                        [[ connectedUsers.length ]] other user[[ connectedUsers.length === 1 ? '' : 's' ]] currently connected
+                    </div>
+                    <div class="small text-muted mb-2">
+                        Based on session activity within the last [[ thresholdMinutes ]] minutes.
+                    </div>
+                    <ul class="list-group list-group-flush">
+                        <li v-for="u in connectedUsers" :key="u.id"
+                            class="list-group-item bg-transparent px-0 py-1 d-flex justify-content-between align-items-center">
+                            <span><i class="fa-solid fa-user me-2 text-muted"></i>[[ u.name ]] <small class="text-muted">([[ u.email ]])</small></span>
+                            <span class="text-nowrap">
+                                <small class="text-muted me-2">active [[ formatIdle(u.idle_seconds) ]]</small>
+                                <span v-if="u.sessions > 1" class="badge bg-secondary" :title="u.sessions + ' active sessions'">[[ u.sessions ]]</span>
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="alert alert-success mb-2">
+                    <i class="fa-solid fa-circle-check me-1"></i>
+                    No other users with session activity in the last [[ thresholdMinutes ]] minutes.
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-sm btn-secondary" @click="closeReloadDialog" :disabled="reloading">Cancel</button>
+                <button type="button" class="btn btn-sm btn-warning" @click="doReload" :disabled="reloading">
+                    <i class="fa-solid fa-arrows-rotate me-1" :class="{ 'fa-spin': reloading }"></i>
+                    [[ reloading ? 'Reloading…' : (connectedUsers.length ? 'Reload anyway' : 'Reload') ]]
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+<div v-if="showReloadModal" class="modal-backdrop fade show"></div>
+
 {% endblock %}
 
 {% block script %}
@@ -743,6 +796,11 @@
 
             const backupCreated = ref(false)
             const reloading = ref(false)
+            const checkingSessions = ref(false)
+            const showReloadModal = ref(false)
+            const connectedUsers = ref([])
+            const sessionsError = ref(false)
+            const thresholdMinutes = ref(15)
             const originalValues = reactive({})
 
             function filterNumericKey(event) {
@@ -796,10 +854,39 @@
                 editing[key] = false
             }
 
-            async function confirmReload() {
-                if (!confirm('This will gracefully restart all application workers to pick up config.py changes. Active requests will finish before reloading. Continue?')) {
-                    return
+            async function openReloadDialog() {
+                checkingSessions.value = true
+                connectedUsers.value = []
+                sessionsError.value = false
+                try {
+                    const res = await fetch('/tools/system_settings/active_sessions')
+                    if (res.ok) {
+                        const data = await res.json()
+                        connectedUsers.value = data.sessions || []
+                        if (data.threshold_minutes) thresholdMinutes.value = data.threshold_minutes
+                    } else {
+                        sessionsError.value = true
+                    }
+                } catch (e) {
+                    sessionsError.value = true
+                } finally {
+                    checkingSessions.value = false
                 }
+                showReloadModal.value = true
+            }
+
+            function formatIdle(seconds) {
+                if (seconds < 60) return 'just now'
+                const mins = Math.floor(seconds / 60)
+                return mins === 1 ? '1 min ago' : mins + ' mins ago'
+            }
+
+            function closeReloadDialog() {
+                if (reloading.value) return
+                showReloadModal.value = false
+            }
+
+            async function doReload() {
                 reloading.value = true
                 try {
                     const res = await fetch('/tools/system_settings/reload', {
@@ -810,6 +897,7 @@
                     })
                     const data = await res.json()
                     if (res.ok) {
+                        showReloadModal.value = false
                         message_list.value.push({ message: data.message, type: 'success' })
                         // Wait for workers to restart, then reload the page
                         setTimeout(() => { window.location.reload() }, 3000)
@@ -829,11 +917,19 @@
                 editValues,
                 backupCreated,
                 reloading,
+                checkingSessions,
+                showReloadModal,
+                connectedUsers,
+                sessionsError,
+                thresholdMinutes,
                 filterNumericKey,
                 startEdit,
                 saveEdit,
                 cancelEdit,
-                confirmReload
+                formatIdle,
+                openReloadDialog,
+                closeReloadDialog,
+                doReload
             }
         }
     }).mount('#main-container')

--- a/app/tools/tools.py
+++ b/app/tools/tools.py
@@ -816,6 +816,18 @@ def system_settings_save():
     return jsonify({"message": "Configuration saved", "backup_created": True})
 
 
+@tools_blueprint.route("/system_settings/active_sessions", methods=["GET"])
+@login_required
+@admin_required
+def system_settings_active_sessions():
+    """List other users currently connected, so a reload can be confirmed knowingly."""
+    sessions = AdminModel.list_active_user_sessions(exclude_user_id=current_user.id)
+    return jsonify({
+        "sessions": sessions,
+        "threshold_minutes": AdminModel.ACTIVE_SESSION_THRESHOLD_MINUTES,
+    })
+
+
 @tools_blueprint.route("/system_settings/reload", methods=["POST"])
 @login_required
 @admin_required


### PR DESCRIPTION
- Check for active sessions
- Warn admin for restart / active sessions
- Fixes https://github.com/flowintel/flowintel/issues/264

- Takes into account 15' of "activity". The redis sessions live longer, so they are not a reliable source as such.
- Excludes current admin account

<img width="456" height="331" alt="image" src="https://github.com/user-attachments/assets/eb3f4e08-568e-4a16-af51-a3bad69f13b5" />
