### PR TITLE
fix: default tasks order is reversed

### DIFF
--- a/app/templates/case/case_view.html
+++ b/app/templates/case/case_view.html
@@ -928,7 +928,7 @@
                 let current_filter = ""
                 const search_query = ref('')
                 let searchTimer = null
-                let asc_desc = true
+                let asc_desc = false
                 let or_and_taxo = true
                 let or_and_galaxies = true
 


### PR DESCRIPTION
fixes issue when after a brand new install, the default sample cases show the tasks reverse-ordered 