### PR TITLE
fix/sqlalchemy_bug_duplicate_tag_names 

### DIFF
--- a/app/custom_tags/custom_tags.py
+++ b/app/custom_tags/custom_tags.py
@@ -121,11 +121,15 @@ def change_config():
             if "custom_tag_color" in request.json["result_dict"] and request.json["result_dict"]["custom_tag_color"]:
                 if "custom_tag_icon" not in request.json["result_dict"] or not request.json["result_dict"]["custom_tag_icon"]:
                     request.json["result_dict"]["custom_tag_icon"] = ""
-                    
+
+                existing_tag = CustomCore.get_custom_tag_by_name(request.json["result_dict"]["custom_tag_name"].strip())
+                if existing_tag and str(existing_tag.id) != str(request.json["result_dict"]["custom_tag_id"]):
+                    return {'message': 'A custom tag with this name already exists', 'toast_class': "warning-subtle"}, 409
+
                 res = CustomCore.change_config_core(request.json["result_dict"])
                 if res:
                     flowintel_log("audit", 200, "Custom tag edited", User=current_user.email, CustomTagId=request.json["result_dict"]["custom_tag_id"], CustomTagName=request.json["result_dict"]["custom_tag_name"])
-                    return {'message': 'Config changed', 'toast_class': "success-subtle"}, 200
+                    return {'message': 'Custom tag updated', 'toast_class': "success-subtle"}, 200
                 return {'message': 'Something went wrong', 'toast_class': "danger-subtle"}, 400                    
             return {'message': 'Need to pass "custom_tag_color"', 'toast_class': "warning-subtle"}, 400
         return {'message': 'Need to pass "custom_tag_name"', 'toast_class': "warning-subtle"}, 400

--- a/app/custom_tags/custom_tags_core.py
+++ b/app/custom_tags/custom_tags_core.py
@@ -27,7 +27,7 @@ def change_config_core(request_json):
     """Change config for a custom_tag"""
     custom_tag = get_custom_tag(request_json["custom_tag_id"])
     if custom_tag:
-        custom_tag.name = request_json["custom_tag_name"]
+        custom_tag.name = request_json["custom_tag_name"].strip()
         custom_tag.icon = request_json["custom_tag_icon"]
         custom_tag.color = request_json["custom_tag_color"]
         db.session.commit()


### PR DESCRIPTION
- Capture SQLAlchemy bug when editing a custom tag and changing it to a tag name that already exists
`sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: custom__tags.name`
- This was already captured on create and via API; edit flow was missing
- "Trim" custom tag names; get rid of spaces
- Update toast when editing a custom tag name