### PR TITLE
fix(ci/test): Typos on some boolean in config.py.default and SIMPLE_S…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ configure_repo_dev:
 	# MacOS Tweak: Let's ignore the error exit code 1 on MacOS (file already exist -> no overwrite)
 	cp -n conf/config.py.default conf/config.py
 	cp -n conf/config_module.py.default conf/config_module.py
+	cp -n conf/saml/settings.json.template conf/saml/settings.json
+	cp -n conf/saml/advanced_settings.json.template conf/saml/advanced_settings.json
 	#
 	cp -n template.env.full.mariadb .env.full.mariadb.custom
 	cp -n template.env.full.postgres .env.full.postgres.custom

--- a/conf/config.py.default
+++ b/conf/config.py.default
@@ -268,11 +268,11 @@ class Config():
     # =============================================================================
     # Enable Mermaid rendering in markdown views and live previews.
     # Set to false to keep Mermaid blocks as plain markdown/code in the UI.
-    ENABLE_MERMAID = env_bool('ENABLE_MERMAID', default=true)
+    ENABLE_MERMAID = env_bool('ENABLE_MERMAID', default=True)
 
     # Enable Mermaid rendering during server-side note exports (PDF/DOCX).
     # Set to false to disable Mermaid Pandoc filters entirely.
-    ENABLE_MERMAID_EXPORT = env_bool('ENABLE_MERMAID_EXPORT', default=true)
+    ENABLE_MERMAID_EXPORT = env_bool('ENABLE_MERMAID_EXPORT', default=True)
 
     # =============================================================================
     # ENTRA ID
@@ -322,14 +322,14 @@ class Config():
     # =============================================================================
     # SIMPLESAML PHP
     # =============================================================================
-    SIMPLESAML_ENABLED        = env_bool('SIMPLESAML_ENABLED', default=true)
-    SIMPLESAML_TRUST_PROXY_HEADERS = env_bool('SIMPLESAML_TRUST_PROXY_HEADERS', default=true)
+    SIMPLESAML_ENABLED        = env_bool('SIMPLESAML_ENABLED', default=False)
+    SIMPLESAML_TRUST_PROXY_HEADERS = env_bool('SIMPLESAML_TRUST_PROXY_HEADERS', default=True)
     # Standard approach for config for python3-saml
     # Note: in settings for Saml, acs is probably analag to redirect in keycloak
     SIMPLESAML_PYTHON3_SAML_PATH = os.getenv('SIMPLESAML_PYTHON3_SAML_PATH', '/home/flowintel/app/conf/saml')
     #
     SIMPLESAML_METADATA_FILE     = os.getenv('SIMPLESAML_METADATA_FILE', 'saml2_metadata.xml')
-    SIMPLESAML_SYNC_ROLE_ON_LOGIN = env_bool('SIMPLESAML_SYNC_ROLE_ON_LOGIN', default=true)
+    SIMPLESAML_SYNC_ROLE_ON_LOGIN = env_bool('SIMPLESAML_SYNC_ROLE_ON_LOGIN', default=True)
     
     # Attribute mapping — SimpleSAMLphp OID URN defaults, override if your IdP uses friendly names
     SIMPLESAML_ATTR_EMAIL      = os.getenv('SIMPLESAML_ATTR_EMAIL', 'urn:oid:0.9.2342.19200300.100.1.3') # 'mail'


### PR DESCRIPTION
…AML as an optional connector should be turned of by default in generic CI tests - Integration tests left to local development -> to that extent, Makefile configure_repo target got an improvement